### PR TITLE
Remove iso-639 lib from pip-requires and lock in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,6 +62,7 @@ jobs:
 
     - name: Initialize environment
       run: |
+        poetry add git+https://github.com/noumar/iso639.git
         poetry add -n --lock $(cat ${{ github.workspace }}/docker/pip-requires.txt)
         poetry install
         npm install

--- a/docker/pip-requires.txt
+++ b/docker/pip-requires.txt
@@ -10,4 +10,3 @@ dulwich==0.20.45
 django-cors-headers@^3.8.0
 sentry-sdk==1.9.8
 click==7.1.2
-iso-639@git+https://github.com/noumar/iso639.git


### PR DESCRIPTION
Remove iso-639 lib from pip-requires and lock in CI. This change is necessary due a error in build image, because the way of lib iso-639 was called in pip requires is not the way that poetry knows 