### PR TITLE
feat: add watchdog mechanism to prevent task overlapping

### DIFF
--- a/temba/flows/tasks.py
+++ b/temba/flows/tasks.py
@@ -53,7 +53,7 @@ def export_flow_results_task(export_id):
     ExportFlowResultsTask.objects.select_related("org", "created_by").get(id=export_id).perform()
 
 
-@nonoverlapping_task(track_started=True, name="squash_flowcounts", lock_timeout=7200)
+@nonoverlapping_task(track_started=True, name="squash_flowcounts", lock_timeout=7200, use_watchdog=True)
 def squash_flowcounts():
     FlowNodeCount.squash()
     FlowRunCount.squash()

--- a/temba/utils/celery.py
+++ b/temba/utils/celery.py
@@ -1,3 +1,5 @@
+import threading
+import time
 from functools import wraps
 
 from django_redis import get_redis_connection
@@ -6,12 +8,35 @@ from celery import shared_task
 
 # for tasks using a redis lock to prevent overlapping this is the default timeout for the lock
 DEFAULT_TASK_LOCK_TIMEOUT = 900
+# how often the watchdog thread should check and extend the lock (in seconds)
+LOCK_REFRESH_INTERVAL = 60
+
+
+def extend_lock(redis_client, lock_key, lock_timeout):
+    """
+    Helper function to extend the TTL of a Redis lock
+    """
+    while True:
+        # Check if the lock still exists
+        if not redis_client.get(lock_key):
+            break
+
+        # Extend the lock TTL
+        redis_client.expire(lock_key, lock_timeout)
+
+        # Wait before next refresh
+        time.sleep(LOCK_REFRESH_INTERVAL)
 
 
 def nonoverlapping_task(*task_args, **task_kwargs):
     """
-    Decorator to create an task whose executions are prevented from overlapping by a redis lock
+    Decorator to create a task whose executions are prevented from overlapping by a redis lock.
+
+    Args:
+        use_watchdog: If True, creates a watchdog thread to extend the lock TTL while the task is running.
     """
+    # Extract watchdog flag from kwargs, defaulting to False
+    use_watchdog = task_kwargs.pop("use_watchdog", False)
 
     def _nonoverlapping_task(task_func):
         @wraps(task_func)
@@ -32,7 +57,25 @@ def nonoverlapping_task(*task_args, **task_kwargs):
                 print("Skipping task %s to prevent overlapping" % task_name)
             else:
                 with r.lock(lock_key, timeout=lock_timeout):
-                    task_func(*exec_args, **exec_kwargs)
+                    if use_watchdog:
+                        # Start watchdog thread to extend lock TTL
+                        watchdog = threading.Thread(
+                            target=extend_lock,
+                            args=(r, lock_key, lock_timeout),
+                            daemon=True,
+                        )
+                        watchdog.start()
+
+                        try:
+                            # Execute the actual task
+                            task_func(*exec_args, **exec_kwargs)
+                        finally:
+                            # The lock will be released by the context manager
+                            # The watchdog thread will stop when it can't find the lock
+                            pass
+                    else:
+                        # Execute without watchdog
+                        task_func(*exec_args, **exec_kwargs)
 
         return shared_task(*task_args, **task_kwargs)(wrapper)
 


### PR DESCRIPTION
Enhance task locking mechanism by introducing a watchdog thread that can extend the Redis lock TTL during long-running tasks. This helps prevent task timeouts and improves reliability for tasks like flow count squashing.