### PR TITLE
add api v2 internal endpoint for open ticket

### DIFF
--- a/temba/api/v2/internals/tickets/serializers.py
+++ b/temba/api/v2/internals/tickets/serializers.py
@@ -1,6 +1,43 @@
 from rest_framework import serializers
 
+from django.contrib.auth import get_user_model
+
+from temba.contacts.models import Contact, ContactURN
+from temba.tickets.models import Ticketer
+
+User = get_user_model()
+
 
 class TicketAssigneeSerializer(serializers.Serializer):
     uuid = serializers.UUIDField()
     email = serializers.EmailField()
+
+
+class OpenTicketSerializer(serializers.Serializer):
+    sector = serializers.UUIDField()
+    contact = serializers.UUIDField(required=False, allow_null=True)
+    contact_urn = serializers.CharField(required=False, allow_null=True, allow_blank=True)
+    assignee = serializers.EmailField(required=False, allow_null=True, allow_blank=True)
+    conversation_started_on = serializers.DateTimeField()
+
+    def validate(self, data):
+        sector_uuid = data.get("sector")
+        contact_uuid = data.get("contact")
+        urn = data.get("contact_urn")
+
+        ticketer = Ticketer.objects.filter(config__sector_uuid=str(sector_uuid)).first()
+        if not ticketer:
+            raise serializers.ValidationError({"ticketer": "ticketer for sector not found"})
+        if contact_uuid is not None:
+            try:
+                ctt = Contact.objects.get(uuid=contact_uuid)
+            except Contact.DoesNotExist:
+                raise serializers.ValidationError({"contact": "contact not found"})
+        else:
+            try:
+                ctt = ContactURN.objects.get(path=urn)
+                data["contact"] = ctt.contact.uuid
+            except ContactURN.DoesNotExist:
+                raise serializers.ValidationError({"contact_urn": "contact URN not found"})
+
+        return data

--- a/temba/api/v2/internals/tickets/serializers.py
+++ b/temba/api/v2/internals/tickets/serializers.py
@@ -3,6 +3,7 @@ from rest_framework import serializers
 from django.contrib.auth import get_user_model
 
 from temba.contacts.models import Contact, ContactURN
+from temba.orgs.models import Org
 from temba.tickets.models import Ticketer
 
 User = get_user_model()
@@ -14,6 +15,7 @@ class TicketAssigneeSerializer(serializers.Serializer):
 
 
 class OpenTicketSerializer(serializers.Serializer):
+    project = serializers.UUIDField()
     sector = serializers.UUIDField()
     contact = serializers.UUIDField(required=False, allow_null=True)
     contact_urn = serializers.CharField(required=False, allow_null=True, allow_blank=True)
@@ -21,11 +23,18 @@ class OpenTicketSerializer(serializers.Serializer):
     conversation_started_on = serializers.DateTimeField()
 
     def validate(self, data):
+        project_uuid = data.get("project")
         sector_uuid = data.get("sector")
         contact_uuid = data.get("contact")
         urn = data.get("contact_urn")
 
-        ticketer = Ticketer.objects.filter(config__sector_uuid=str(sector_uuid)).first()
+        try:
+            org = Org.objects.get(proj_uuid=project_uuid)
+            data["org_id"] = org.id
+        except Org.DoesNotExist:
+            raise serializers.ValidationError({"project": "project not found"})
+
+        ticketer = Ticketer.objects.filter(config__sector_uuid=str(sector_uuid), org_id=org.id).first()
         if not ticketer:
             raise serializers.ValidationError({"ticketer": "ticketer for sector not found"})
         if contact_uuid is not None:
@@ -35,7 +44,7 @@ class OpenTicketSerializer(serializers.Serializer):
                 raise serializers.ValidationError({"contact": "contact not found"})
         else:
             try:
-                ctt = ContactURN.objects.get(path=urn)
+                ctt = ContactURN.objects.get(path=urn, org_id=org.id)
                 data["contact"] = ctt.contact.uuid
             except ContactURN.DoesNotExist:
                 raise serializers.ValidationError({"contact_urn": "contact URN not found"})

--- a/temba/api/v2/internals/tickets/tests.py
+++ b/temba/api/v2/internals/tickets/tests.py
@@ -1,5 +1,11 @@
 from unittest.mock import patch
 
+from rest_framework import status
+from rest_framework.response import Response
+
+from django.contrib.auth.models import User
+
+from temba.api.v2.validators import LambdaURLValidator
 from temba.tests import TembaTest
 from temba.tickets.models import Ticket, Ticketer
 
@@ -53,3 +59,237 @@ class TicketAssigneeViewTest(TembaTest):
 
         ticket.refresh_from_db()
         self.assertEqual(ticket.assignee.email, "user_email@email.com")
+
+
+class OpenTicketTest(TembaTest):
+    def setUp(self):
+        super().setUp()
+        self.joe = self.create_contact("Joe Blow", phone="123", fields={"age": "17", "gender": "male"})
+        self.ticketer = Ticketer.create(
+            self.org,
+            self.admin,
+            "wenichats",
+            "Support Tickets",
+            {"sector_uuid": "30df650c-f15a-4996-b825-2a35cdc941cc"},
+        )
+
+    def ticket_open_return_value(self):
+        return Response(
+            {
+                "body": '{"history_after":"2025-01-01 00:00:00"}',
+                "external_id": "8ecb1e4a-b457-4645-a161-e2b02ddffa88",
+                "ticketer": {
+                    "name": self.ticketer.name,
+                    "uuid": self.ticketer.uuid,
+                },
+                "topic": {
+                    "name": "General",
+                    "queue_uuid": self.org.default_ticket_topic.queue_uuid,
+                    "uuid": self.org.default_ticket_topic.uuid,
+                },
+                "uuid": "970b8069-50f5-4f6f-8f41-6b2d9f33d623",
+            },
+            status=status.HTTP_200_OK,
+        )
+
+    @patch.object(LambdaURLValidator, "protected_resource")
+    @patch("temba.mailroom.client.MailroomClient.ticket_open")
+    def test_open_ticket(self, mock_ticket_open, mock_protected_resource):
+        mock_protected_resource.return_value = Response({"message": "Access granted!"}, status=status.HTTP_200_OK)
+
+        mock_ticket_open.return_value = self.ticket_open_return_value()
+
+        url = "/api/v2/internals/open_ticket"
+        body = {
+            "sector": self.ticketer.config["sector_uuid"],
+            "contact": self.joe.uuid,
+            "assignee": "user_email@email.com",
+            "queue": self.org.default_ticket_topic.queue_uuid,
+            "conversation_started_on": "2025-01-01 00:00:00",
+        }
+        response = self.client.post(url, data=body, content_type="application/json")
+
+        mock_ticket_open.assert_called_once_with(
+            self.org.id,
+            self.joe.id,
+            self.ticketer.id,
+            self.org.default_ticket_topic.id,
+            0,
+            '{"history_after":"2025-01-01 00:00:00+02:00"}',
+        )
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.data["uuid"], "970b8069-50f5-4f6f-8f41-6b2d9f33d623")
+        self.assertEqual(response.data["topic"]["uuid"], self.org.default_ticket_topic.uuid)
+
+    @patch.object(LambdaURLValidator, "protected_resource")
+    @patch("temba.mailroom.client.MailroomClient.ticket_open")
+    def test_open_ticket_without_assignee_and_queue(self, mock_ticket_open, mock_protected_resource):
+        mock_protected_resource.return_value = Response({"message": "Access granted!"}, status=status.HTTP_200_OK)
+
+        mock_ticket_open.return_value = self.ticket_open_return_value()
+
+        url = "/api/v2/internals/open_ticket"
+        body = {
+            "sector": self.ticketer.config["sector_uuid"],
+            "contact": self.joe.uuid,
+            "conversation_started_on": "2025-01-01 00:00:00",
+        }
+        response = self.client.post(url, data=body, content_type="application/json")
+
+        print("RESPONSE_DATA:")
+        print(response.data)
+
+        self.assertEqual(response.status_code, 200)
+
+    @patch.object(LambdaURLValidator, "protected_resource")
+    @patch("temba.mailroom.client.MailroomClient.ticket_open")
+    def test_open_ticket_with_assignee_and_queue_empty(self, mock_ticket_open, mock_protected_resource):
+        mock_protected_resource.return_value = Response({"message": "Access granted!"}, status=status.HTTP_200_OK)
+
+        mock_ticket_open.return_value = self.ticket_open_return_value()
+
+        url = "/api/v2/internals/open_ticket"
+        body = {
+            "sector": self.ticketer.config["sector_uuid"],
+            "contact": self.joe.uuid,
+            "assignee": "",
+            "queue": "",
+            "conversation_started_on": "2025-01-01 00:00:00",
+        }
+        response = self.client.post(url, data=body, content_type="application/json")
+
+        self.assertEqual(response.status_code, 200)
+
+    @patch.object(LambdaURLValidator, "protected_resource")
+    @patch("temba.mailroom.client.MailroomClient.ticket_open")
+    def test_open_ticket_with_urn(self, mock_ticket_open, mock_protected_resource):
+        mock_protected_resource.return_value = Response({"message": "Access granted!"}, status=status.HTTP_200_OK)
+
+        mock_ticket_open.return_value = self.ticket_open_return_value()
+
+        url = "/api/v2/internals/open_ticket"
+        body = {
+            "sector": self.ticketer.config["sector_uuid"],
+            "contact_urn": self.joe.urns.first().path,
+            "assignee": "user_email@email.com",
+            "queue": self.org.default_ticket_topic.queue_uuid,
+            "conversation_started_on": "2025-01-01 00:00:00",
+        }
+        response = self.client.post(url, data=body, content_type="application/json")
+
+        mock_ticket_open.assert_called_once_with(
+            self.org.id,
+            self.joe.id,
+            self.ticketer.id,
+            self.org.default_ticket_topic.id,
+            0,
+            '{"history_after":"2025-01-01 00:00:00+02:00"}',
+        )
+
+        self.assertEqual(response.status_code, 200)
+
+    @patch.object(LambdaURLValidator, "protected_resource")
+    def test_open_ticket_without_ticketer(self, mock_protected_resource):
+        mock_protected_resource.return_value = Response({"message": "Access granted!"}, status=status.HTTP_200_OK)
+
+        url = "/api/v2/internals/open_ticket"
+        body = {
+            "sector": "1cfa4c9e-d69b-436c-971e-ca444334b60f",
+            "contact": self.joe.uuid,
+            "assignee": "user_email@email.com",
+            "queue": self.org.default_ticket_topic.queue_uuid,
+            "conversation_started_on": "2025-01-01 00:00:00",
+        }
+        response = self.client.post(url, data=body, content_type="application/json")
+
+        self.assertEqual(response.status_code, 400)
+
+    @patch.object(LambdaURLValidator, "protected_resource")
+    @patch("temba.mailroom.client.MailroomClient.ticket_open")
+    def test_open_ticket_default_topic_if_not_found(self, mock_ticket_open, mock_protected_resource):
+        mock_protected_resource.return_value = Response({"message": "Access granted!"}, status=status.HTTP_200_OK)
+
+        mock_ticket_open.return_value = self.ticket_open_return_value()
+
+        url = "/api/v2/internals/open_ticket"
+        body = {
+            "sector": self.ticketer.config["sector_uuid"],
+            "contact": self.joe.uuid,
+            "assignee": "user_email@email.com",
+            "queue": "76d73017-7479-4817-960c-a154d3dac4a1",
+            "conversation_started_on": "2025-01-01 00:00:00",
+        }
+        response = self.client.post(url, data=body, content_type="application/json")
+
+        mock_ticket_open.assert_called_once_with(
+            self.org.id,
+            self.joe.id,
+            self.ticketer.id,
+            self.org.default_ticket_topic.id,
+            0,
+            '{"history_after":"2025-01-01 00:00:00+02:00"}',
+        )
+
+        self.assertEqual(response.status_code, 200)
+
+    @patch.object(LambdaURLValidator, "protected_resource")
+    @patch("temba.mailroom.client.MailroomClient.ticket_open")
+    def test_open_ticket_with_assignee(self, mock_ticket_open, mock_protected_resource):
+        self.user = User.objects.create_user(username="suppport", email="suppport@email.com")
+        mock_protected_resource.return_value = Response({"message": "Access granted!"}, status=status.HTTP_200_OK)
+
+        mock_ticket_open.return_value = self.ticket_open_return_value()
+
+        url = "/api/v2/internals/open_ticket"
+        body = {
+            "sector": self.ticketer.config["sector_uuid"],
+            "contact": self.joe.uuid,
+            "assignee": self.user.email,
+            "queue": self.org.default_ticket_topic.queue_uuid,
+            "conversation_started_on": "2025-01-01 00:00:00",
+        }
+        response = self.client.post(url, data=body, content_type="application/json")
+
+        mock_ticket_open.assert_called_once_with(
+            self.org.id,
+            self.joe.id,
+            self.ticketer.id,
+            self.org.default_ticket_topic.id,
+            self.user.id,
+            '{"history_after":"2025-01-01 00:00:00+02:00"}',
+        )
+
+        self.assertEqual(response.status_code, 200)
+
+    @patch.object(LambdaURLValidator, "protected_resource")
+    def test_open_ticket_wrong_contact(self, mock_protected_resource):
+        mock_protected_resource.return_value = Response({"message": "Access granted!"}, status=status.HTTP_200_OK)
+
+        url = "/api/v2/internals/open_ticket"
+        body = {
+            "sector": self.ticketer.config["sector_uuid"],
+            "contact": "0f3e1b46-a58e-4246-8fae-52bfd3087850",
+            "assignee": "user_email@email.com",
+            "queue": self.org.default_ticket_topic.queue_uuid,
+            "conversation_started_on": "2025-01-01 00:00:00",
+        }
+        response = self.client.post(url, data=body, content_type="application/json")
+
+        self.assertEqual(response.status_code, 400)
+
+    @patch.object(LambdaURLValidator, "protected_resource")
+    def test_open_ticket_wrong_urn(self, mock_protected_resource):
+        mock_protected_resource.return_value = Response({"message": "Access granted!"}, status=status.HTTP_200_OK)
+
+        url = "/api/v2/internals/open_ticket"
+        body = {
+            "sector": self.ticketer.config["sector_uuid"],
+            "contact_urn": "5582998765432",
+            "assignee": "user_email@email.com",
+            "queue": self.org.default_ticket_topic.queue_uuid,
+            "conversation_started_on": "2025-01-01 00:00:00",
+        }
+        response = self.client.post(url, data=body, content_type="application/json")
+
+        self.assertEqual(response.status_code, 400)

--- a/temba/api/v2/internals/tickets/tests.py
+++ b/temba/api/v2/internals/tickets/tests.py
@@ -101,6 +101,7 @@ class OpenTicketTest(TembaTest):
 
         url = "/api/v2/internals/open_ticket"
         body = {
+            "project": self.org.proj_uuid,
             "sector": self.ticketer.config["sector_uuid"],
             "contact": self.joe.uuid,
             "assignee": "user_email@email.com",
@@ -131,14 +132,12 @@ class OpenTicketTest(TembaTest):
 
         url = "/api/v2/internals/open_ticket"
         body = {
+            "project": self.org.proj_uuid,
             "sector": self.ticketer.config["sector_uuid"],
             "contact": self.joe.uuid,
             "conversation_started_on": "2025-01-01 00:00:00",
         }
         response = self.client.post(url, data=body, content_type="application/json")
-
-        print("RESPONSE_DATA:")
-        print(response.data)
 
         self.assertEqual(response.status_code, 200)
 
@@ -151,6 +150,7 @@ class OpenTicketTest(TembaTest):
 
         url = "/api/v2/internals/open_ticket"
         body = {
+            "project": self.org.proj_uuid,
             "sector": self.ticketer.config["sector_uuid"],
             "contact": self.joe.uuid,
             "assignee": "",
@@ -170,6 +170,7 @@ class OpenTicketTest(TembaTest):
 
         url = "/api/v2/internals/open_ticket"
         body = {
+            "project": self.org.proj_uuid,
             "sector": self.ticketer.config["sector_uuid"],
             "contact_urn": self.joe.urns.first().path,
             "assignee": "user_email@email.com",
@@ -195,6 +196,7 @@ class OpenTicketTest(TembaTest):
 
         url = "/api/v2/internals/open_ticket"
         body = {
+            "project": self.org.proj_uuid,
             "sector": "1cfa4c9e-d69b-436c-971e-ca444334b60f",
             "contact": self.joe.uuid,
             "assignee": "user_email@email.com",
@@ -214,6 +216,7 @@ class OpenTicketTest(TembaTest):
 
         url = "/api/v2/internals/open_ticket"
         body = {
+            "project": self.org.proj_uuid,
             "sector": self.ticketer.config["sector_uuid"],
             "contact": self.joe.uuid,
             "assignee": "user_email@email.com",
@@ -243,6 +246,7 @@ class OpenTicketTest(TembaTest):
 
         url = "/api/v2/internals/open_ticket"
         body = {
+            "project": self.org.proj_uuid,
             "sector": self.ticketer.config["sector_uuid"],
             "contact": self.joe.uuid,
             "assignee": self.user.email,
@@ -268,6 +272,7 @@ class OpenTicketTest(TembaTest):
 
         url = "/api/v2/internals/open_ticket"
         body = {
+            "project": self.org.proj_uuid,
             "sector": self.ticketer.config["sector_uuid"],
             "contact": "0f3e1b46-a58e-4246-8fae-52bfd3087850",
             "assignee": "user_email@email.com",
@@ -284,6 +289,24 @@ class OpenTicketTest(TembaTest):
 
         url = "/api/v2/internals/open_ticket"
         body = {
+            "project": self.org.proj_uuid,
+            "sector": self.ticketer.config["sector_uuid"],
+            "contact_urn": "5582998765432",
+            "assignee": "user_email@email.com",
+            "queue": self.org.default_ticket_topic.queue_uuid,
+            "conversation_started_on": "2025-01-01 00:00:00",
+        }
+        response = self.client.post(url, data=body, content_type="application/json")
+
+        self.assertEqual(response.status_code, 400)
+
+    @patch.object(LambdaURLValidator, "protected_resource")
+    def test_open_ticket_invalid_project(self, mock_protected_resource):
+        mock_protected_resource.return_value = Response({"message": "Access granted!"}, status=status.HTTP_200_OK)
+
+        url = "/api/v2/internals/open_ticket"
+        body = {
+            "project": "91b45788-8beb-48dd-8355-64aab570e0c9",
             "sector": self.ticketer.config["sector_uuid"],
             "contact_urn": "5582998765432",
             "assignee": "user_email@email.com",

--- a/temba/api/v2/internals/tickets/urls.py
+++ b/temba/api/v2/internals/tickets/urls.py
@@ -1,5 +1,8 @@
 from django.urls import path
 
-from .views import TicketAssigneeView
+from .views import OpenTicketView, TicketAssigneeView
 
-urlpatterns = [path("ticket_assignee", TicketAssigneeView.as_view(), name="ticket_assignee")]
+urlpatterns = [
+    path("ticket_assignee", TicketAssigneeView.as_view(), name="ticket_assignee"),
+    path("open_ticket", OpenTicketView.as_view(), name="open_ticket"),
+]

--- a/temba/api/v2/internals/tickets/views.py
+++ b/temba/api/v2/internals/tickets/views.py
@@ -52,7 +52,10 @@ class OpenTicketView(APIViewMixin, APIView, LambdaURLValidator):
         serializer = OpenTicketSerializer(data=request.data)
         serializer.is_valid(raise_exception=True)
 
-        self.ticketer = Ticketer.objects.filter(config__sector_uuid=str(serializer.validated_data["sector"])).first()
+        self.ticketer = Ticketer.objects.filter(
+            config__sector_uuid=str(serializer.validated_data["sector"]),
+            org_id=serializer.validated_data["org_id"],
+        ).first()
         contact = Contact.objects.get(uuid=serializer.validated_data["contact"])
         topic_id = self.get_topic_id(request)
         assignee_id = self.get_assignee_id(request)

--- a/temba/api/v2/internals/tickets/views.py
+++ b/temba/api/v2/internals/tickets/views.py
@@ -1,5 +1,6 @@
 from rest_framework import status
 from rest_framework.permissions import IsAuthenticated
+from rest_framework.renderers import JSONRenderer
 from rest_framework.request import Request
 from rest_framework.response import Response
 from rest_framework.views import APIView
@@ -9,9 +10,12 @@ from weni.internal.permissions import CanCommunicateInternally
 from django.contrib.auth import get_user_model
 from django.shortcuts import get_object_or_404
 
-from temba.api.v2.internals.tickets.serializers import TicketAssigneeSerializer
+from temba import mailroom
+from temba.api.v2.internals.tickets.serializers import OpenTicketSerializer, TicketAssigneeSerializer
 from temba.api.v2.internals.views import APIViewMixin
-from temba.tickets.models import Ticket
+from temba.api.v2.validators import LambdaURLValidator
+from temba.contacts.models import Contact
+from temba.tickets.models import Ticket, Ticketer, Topic
 
 User = get_user_model()
 
@@ -35,3 +39,46 @@ class TicketAssigneeView(APIViewMixin, APIView):
         response = {"results": {"ticketer": ticket.uuid, "assignee": ticket.assignee.email}}
 
         return Response(response, status=status.HTTP_200_OK)
+
+
+class OpenTicketView(APIViewMixin, APIView, LambdaURLValidator):
+    renderer_classes = [JSONRenderer]
+
+    def post(self, request, *args, **kwargs):
+        validation_response = self.protected_resource(request)  # pragma: no cover
+        if validation_response.status_code != 200:  # pragma: no cover
+            return validation_response
+
+        serializer = OpenTicketSerializer(data=request.data)
+        serializer.is_valid(raise_exception=True)
+
+        self.ticketer = Ticketer.objects.filter(config__sector_uuid=str(serializer.validated_data["sector"])).first()
+        contact = Contact.objects.get(uuid=serializer.validated_data["contact"])
+        topic_id = self.get_topic_id(request)
+        assignee_id = self.get_assignee_id(request)
+        extra = f'{{"history_after":"{serializer.validated_data["conversation_started_on"]}"}}'
+
+        return mailroom.get_client().ticket_open(
+            self.ticketer.org.id, contact.id, self.ticketer.id, topic_id, assignee_id, extra
+        )
+
+    def get_assignee_id(self, request):
+        assignee = request.data.get("assignee")
+        if assignee:
+            try:
+                assignee_user = User.objects.get(email=assignee)
+                return assignee_user.id
+            except User.DoesNotExist:
+                pass
+        return 0
+
+    def get_topic_id(self, request):
+        queue = request.data.get("queue")
+        if queue:
+            try:
+                topic = Topic.objects.get(queue_uuid=queue)
+                return topic.id
+            except Topic.DoesNotExist:
+                pass
+
+        return self.ticketer.org.topics.get(is_default=True).id

--- a/temba/mailroom/client.py
+++ b/temba/mailroom/client.py
@@ -208,6 +208,17 @@ class MailroomClient:
 
         return self._request("ticket/close", payload)
 
+    def ticket_open(self, org_id: int, contact_id: int, ticketer_id: int, topic_id: int, assignee_id: int, extra: str):
+        payload = {
+            "org_id": org_id,
+            "contact_id": contact_id,
+            "ticketer_id": ticketer_id,
+            "topic_id": topic_id,
+            "assignee_id": assignee_id,
+            "extra": extra,
+        }
+        return self._request("ticket/open", payload)
+
     def ticket_reopen(self, org_id, user_id, ticket_ids):
         payload = {"org_id": org_id, "user_id": user_id, "ticket_ids": ticket_ids}
 

--- a/temba/mailroom/tests.py
+++ b/temba/mailroom/tests.py
@@ -371,6 +371,43 @@ class MailroomClientTest(TembaTest):
                 json={"org_id": 1, "user_id": 12, "ticket_ids": [123, 345], "force": True},
             )
 
+    def test_ticket_open(self):
+        with patch("requests.post") as mock_post:
+            response = """{
+                "assignee": {
+                    "email": "admin1@nyaruka.com",
+                    "name": "Andy Admin"
+                },
+                "body": "",
+                "external_id": "8ecb1e4a-b457-4645-a161-e2b02ddffa88",
+                "ticketer": {
+                    "name": "Weni Chats",
+                    "uuid": "006d224e-107f-4e18-afb2-f41fe302abdc"
+                },
+                "topic": {
+                    "name": "General",
+                    "queue_uuid": "5c85fdf7-d54a-49dd-97ed-7e10077a1f6a",
+                    "uuid": "ffc903f7-8cbb-443f-9627-87106842d1aa"
+                },
+                "uuid": "692926ea-09d6-4942-bd38-d266ec8d3716"
+            }"""
+            mock_post.return_value = MockResponse(200, response)
+            response = get_client().ticket_open(1, 10000, 7, 1, 1, "")
+
+            self.assertEqual("692926ea-09d6-4942-bd38-d266ec8d3716", response["uuid"])
+            mock_post.assert_called_once_with(
+                "http://localhost:8090/mr/ticket/open",
+                headers={"User-Agent": "Temba"},
+                json={
+                    "org_id": 1,
+                    "contact_id": 10000,
+                    "ticketer_id": 7,
+                    "topic_id": 1,
+                    "assignee_id": 1,
+                    "extra": "",
+                },
+            )
+
     def test_ticket_reopen(self):
         with patch("requests.post") as mock_post:
             mock_post.return_value = MockResponse(200, '{"changed_ids": [123]}')


### PR DESCRIPTION
Endpoint to open ticket with an alternative authentication using aws roles.

**Request Details:**

URL: https://flows.stg.cloud.weni.ai/api/v2/internals/open_ticket
Method: POST
Authentication: AWS Lambda authentication
Content-Type: application/json
Body:
```json
{
    "project": <project_uuid>,
    "sector": <sector_uuid>,
    "contact": <contact_uuid>,
    "assignee": <user_email>,
    "queue": <queue_uuid>,
    "conversation_started_on": <"2025-01-01 00:00:00">
}
```

Contact can be passed as:

- contact: <contact_uuid>
- contact_urn: 5582999887766
Optional fields:
- 
- assignee and queue can be empty or omitted.

Expected Response:

- status_code: 200
- body:

```
{
    "body": '{"history_after":"2025-01-01 00:00:00"}',
    "external_id": "8ecb1e4a-b457-4645-a161-e2b02ddffa88",
    "ticketer": {
        "name": ticketer.name,
        "uuid": ticketer.uuid,
    },
    "topic": {
        "name": "General",
        "queue_uuid": queue_uuid,
        "uuid": topic.uuid,
    },
    "uuid": "970b8069-50f5-4f6f-8f41-6b2d9f33d623",
}
```
