### PR TITLE
Add queue field to WhatsappBroadcastWriteSerializer

### DIFF
--- a/temba/api/v2/serializers.py
+++ b/temba/api/v2/serializers.py
@@ -285,6 +285,7 @@ class WhatsappBroadcastWriteSerializer(WriteSerializer):
     groups = fields.ContactGroupField(many=True, required=False)
     msg = serializers.DictField(required=True)
     channel = serializers.UUIDField(required=False)
+    queue = serializers.CharField(required=False)
 
     def validate_msg(self, value):
         if not (value.get("text") or value.get("attachments") or value.get("template") or value.get("action_type")):
@@ -313,6 +314,10 @@ class WhatsappBroadcastWriteSerializer(WriteSerializer):
             template = data["msg"]["template"]
             if not channel.template_translations.filter(template__uuid=template["uuid"]).exists():
                 raise serializers.ValidationError(f"Template {template['uuid']} not found in channel {channel.uuid}")
+
+        if data.get("queue"):
+            if data.get("queue") not in ["wpp_broadcast_batch", "template_batch", "template_notification_batch"]:
+                raise serializers.ValidationError("Queue must be either wpp_broadcast_batch, template_batch or template_notification_batch")
 
         return data
 
@@ -363,6 +368,7 @@ class WhatsappBroadcastWriteSerializer(WriteSerializer):
             msg=self.validated_data.get("msg", {}),
             channel=self.validated_data.get("channel", None),
             broadcast_type=Broadcast.BROADCAST_TYPE_WHATSAPP,
+            queue=self.validated_data.get("queue", None),
         )
         # send it
         on_transaction_commit(lambda: broadcast.send_async())

--- a/temba/api/v2/serializers.py
+++ b/temba/api/v2/serializers.py
@@ -317,7 +317,9 @@ class WhatsappBroadcastWriteSerializer(WriteSerializer):
 
         if data.get("queue"):
             if data.get("queue") not in ["wpp_broadcast_batch", "template_batch", "template_notification_batch"]:
-                raise serializers.ValidationError("Queue must be either wpp_broadcast_batch, template_batch or template_notification_batch")
+                raise serializers.ValidationError(
+                    "Queue must be either wpp_broadcast_batch, template_batch or template_notification_batch"
+                )
 
         return data
 

--- a/temba/mailroom/queue.py
+++ b/temba/mailroom/queue.py
@@ -101,6 +101,10 @@ def queue_broadcast(broadcast):
         _queue_batch_task(broadcast.org_id, BatchTask.SEND_BROADCAST, task, HIGH_PRIORITY)
 
     if broadcast.broadcast_type == "W":
+        # ensure metadata is at least an empty dict before we try to access it
+        if not broadcast.metadata:
+            broadcast.metadata = {}
+
         task = {
             "urns": broadcast.raw_urns or [],
             "contact_ids": list(broadcast.contacts.values_list("id", flat=True)),

--- a/temba/mailroom/queue.py
+++ b/temba/mailroom/queue.py
@@ -109,6 +109,7 @@ def queue_broadcast(broadcast):
             "org_id": broadcast.org_id,
             "msg": broadcast.metadata,
             "channel_id": broadcast.channel_id,
+            "queue": broadcast.metadata.get("queue", None),
         }
 
         _queue_batch_task(broadcast.org_id, BatchTask.SEND_WHATSAPP_BROADCAST, task, HIGH_PRIORITY)

--- a/temba/mailroom/queue.py
+++ b/temba/mailroom/queue.py
@@ -105,7 +105,7 @@ def queue_broadcast(broadcast):
         if not broadcast.metadata:
             broadcast.metadata = {}
 
-        # get the queue from the metadata
+        # pop the queue from the metadata
         queue = broadcast.metadata.pop("queue", None)
 
         task = {

--- a/temba/mailroom/queue.py
+++ b/temba/mailroom/queue.py
@@ -105,6 +105,9 @@ def queue_broadcast(broadcast):
         if not broadcast.metadata:
             broadcast.metadata = {}
 
+        # get the queue from the metadata
+        queue = broadcast.metadata.pop("queue", None)
+
         task = {
             "urns": broadcast.raw_urns or [],
             "contact_ids": list(broadcast.contacts.values_list("id", flat=True)),
@@ -113,7 +116,7 @@ def queue_broadcast(broadcast):
             "org_id": broadcast.org_id,
             "msg": broadcast.metadata,
             "channel_id": broadcast.channel_id,
-            "queue": broadcast.metadata.get("queue", None),
+            "queue": queue,
         }
 
         _queue_batch_task(broadcast.org_id, BatchTask.SEND_WHATSAPP_BROADCAST, task, HIGH_PRIORITY)

--- a/temba/mailroom/tests.py
+++ b/temba/mailroom/tests.py
@@ -599,6 +599,7 @@ class MailroomQueueTest(TembaTest):
             broadcast_type=Broadcast.BROADCAST_TYPE_WHATSAPP,
             msg={"text": "Sending a whatsapp text"},
             channel=channel,
+            queue="wpp_broadcast_batch",
         )
 
         bcast.send_async()
@@ -617,6 +618,7 @@ class MailroomQueueTest(TembaTest):
                     "org_id": self.org.id,
                     "msg": {"text": "Sending a whatsapp text"},
                     "channel_id": channel.id,
+                    "queue": "wpp_broadcast_batch",
                 },
                 "queued_on": matchers.ISODate(),
             },

--- a/temba/msgs/models.py
+++ b/temba/msgs/models.py
@@ -156,6 +156,9 @@ class Broadcast(models.Model):
                         % base_language
                     )
 
+        # ensure metadata is at least an empty dict before we try to access it
+        metadata = {}
+
         if broadcast_type == cls.BROADCAST_TYPE_DEFAULT:
             metadata = {Broadcast.METADATA_TEMPLATE_STATE: template_state}
             if quick_replies:

--- a/temba/msgs/models.py
+++ b/temba/msgs/models.py
@@ -156,9 +156,6 @@ class Broadcast(models.Model):
                         % base_language
                     )
 
-        # ensure metadata is at least an empty dict before we try to access it
-        metadata = {}
-
         if broadcast_type == cls.BROADCAST_TYPE_DEFAULT:
             metadata = {Broadcast.METADATA_TEMPLATE_STATE: template_state}
             if quick_replies:
@@ -166,6 +163,10 @@ class Broadcast(models.Model):
 
         if broadcast_type == cls.BROADCAST_TYPE_WHATSAPP:
             metadata = msg
+
+        # ensure metadata is at least an empty dict before we try to access it
+        if not metadata:
+            metadata = {}
 
         if queue:
             metadata[Broadcast.METADATA_QUEUE] = queue

--- a/temba/msgs/models.py
+++ b/temba/msgs/models.py
@@ -76,6 +76,7 @@ class Broadcast(models.Model):
 
     METADATA_QUICK_REPLIES = "quick_replies"
     METADATA_TEMPLATE_STATE = "template_state"
+    METADATA_QUEUE = "queue"
 
     org = models.ForeignKey(Org, on_delete=models.PROTECT)
 
@@ -134,6 +135,7 @@ class Broadcast(models.Model):
         msg: dict = None,
         template_state: str = TEMPLATE_STATE_LEGACY,
         status: str = STATUS_INITIALIZING,
+        queue: str = None,
         **kwargs,
     ):
         # for convenience broadcasts can still be created with single translation and no base_language
@@ -161,6 +163,9 @@ class Broadcast(models.Model):
 
         if broadcast_type == cls.BROADCAST_TYPE_WHATSAPP:
             metadata = msg
+
+        if queue:
+            metadata[Broadcast.METADATA_QUEUE] = queue
 
         broadcast = cls.objects.create(
             org=org,


### PR DESCRIPTION
- Introduced a new optional 'queue' field in WhatsappBroadcastWriteSerializer.
- Added validation to ensure 'queue' value is one of the predefined options.
- Updated the Broadcast model to include 'queue' in metadata.
- Modified queue_broadcast function to handle the new 'queue' field in broadcast metadata.