### PR TITLE
Task squash flow category counts

### DIFF
--- a/temba/flows/tasks.py
+++ b/temba/flows/tasks.py
@@ -57,10 +57,14 @@ def export_flow_results_task(export_id):
 def squash_flowcounts():
     FlowNodeCount.squash()
     FlowRunCount.squash()
-    FlowCategoryCount.squash()
     FlowPathRecentRun.prune()
     FlowStartCount.squash()
     FlowPathCount.squash()
+
+
+@nonoverlapping_task(track_started=True, name="squash_flow_category_counts", lock_timeout=7200)
+def squash_flow_category_counts():
+    FlowCategoryCount.squash()
 
 
 @nonoverlapping_task(track_started=True, name="trim_flow_revisions")


### PR DESCRIPTION
moving the categorycount squash into a new task as I identified the need for this action to be isolated from the others so that it occurs more frequently