### PR TITLE
Refactor OrgCRUDL view to remove unused sections

### DIFF
--- a/temba/archives/tests.py
+++ b/temba/archives/tests.py
@@ -261,24 +261,6 @@ class ArchiveCRUDLTest(TembaTest, CRUDLTestMixin):
 
         self.assertIn(download_url, response.get("Location"))
 
-    def test_formax(self):
-        self.login(self.admin)
-        url = reverse("orgs.org_home")
-
-        response = self.client.get(url)
-        self.assertContains(response, "archives yet")
-        self.assertContains(response, reverse("archives.archive_message"))
-
-        d1 = self.create_archive(Archive.TYPE_MSG, "D", date(2020, 7, 31), [{"id": 1}, {"id": 2}, {"id": 3}])
-        self.create_archive(
-            Archive.TYPE_MSG, "M", date(2020, 7, 1), [{"id": 1}, {"id": 2}, {"id": 3}], rollup_of=(d1,)
-        )
-        self.create_archive(Archive.TYPE_MSG, "D", date(2020, 8, 1), [{"id": 4}])
-
-        response = self.client.get(url)
-        self.assertContains(response, "4 records")
-        self.assertContains(response, reverse("archives.archive_message"))
-
 
 class JSONLGZTest(TembaTest):
     def test_jsonlgz_rewrite(self):

--- a/temba/orgs/integrations/dtone/tests.py
+++ b/temba/orgs/integrations/dtone/tests.py
@@ -16,10 +16,6 @@ class DTOneTypeTest(TembaTest):
         self.login(self.admin)
 
         account_url = reverse("integrations.dtone.account")
-        home_url = reverse("orgs.org_home")
-
-        response = self.client.get(home_url)
-        self.assertContains(response, "Connect your DT One account.")
 
         # formax includes form to connect account
         response = self.client.get(account_url, HTTP_X_FORMAX=True)
@@ -45,11 +41,6 @@ class DTOneTypeTest(TembaTest):
         self.assertTrue(self.org.get_integrations(IntegrationType.Category.AIRTIME))
         self.assertEqual("key123", self.org.config["dtone_key"])
         self.assertEqual("sesame", self.org.config["dtone_secret"])
-
-        # and that stated on home page
-        response = self.client.get(home_url)
-        self.assertContains(response, "Connected to your DT One account.")
-        self.assertContains(response, reverse("airtime.airtimetransfer_list"))
 
         # formax includes the disconnect link
         response = self.client.get(account_url, HTTP_X_FORMAX=True)
@@ -89,4 +80,4 @@ class DTOneClientTest(TembaTest):
         with self.assertRaises(DTOneClient.Exception) as error:
             self.client.get_balances()
 
-        self.assertEqual(str(error.exception), f"Unauthorized")
+        self.assertEqual(str(error.exception), "Unauthorized")

--- a/temba/orgs/tests.py
+++ b/temba/orgs/tests.py
@@ -481,7 +481,7 @@ class UserTest(TembaTest):
 
     @override_settings(USER_LOCKOUT_TIMEOUT=1, USER_FAILED_LOGIN_LIMIT=3)
     def test_confirm_access(self):
-        confirm_url = reverse("users.confirm_access") + f"?next=/msg/inbox/"
+        confirm_url = reverse("users.confirm_access") + "?next=/msg/inbox/"
         failed_url = reverse("users.user_failed")
 
         # try to access before logging in
@@ -1044,7 +1044,6 @@ class OrgTest(TembaTest):
     def test_country_view(self):
         self.setUpLocations()
 
-        home_url = reverse("orgs.org_home")
         country_url = reverse("orgs.org_country")
 
         rwanda = AdminBoundary.objects.get(name="Rwanda")
@@ -1064,15 +1063,6 @@ class OrgTest(TembaTest):
         self.org.refresh_from_db()
         self.assertEqual("Rwanda", str(self.org.country))
         self.assertEqual("RW", self.org.default_country_code)
-
-        response = self.client.get(home_url)
-        self.assertContains(response, "Rwanda")
-
-        # if location support is disabled in the branding, don't display country formax
-        current_branding = settings.BRANDING["rapidpro.io"]
-        with override_settings(BRANDING={"rapidpro.io": {**current_branding, "location_support": False}}):
-            response = self.client.get(home_url)
-            self.assertNotContains(response, "Rwanda")
 
     def test_default_country(self):
         # if country boundary is set and name is valid country, that has priority
@@ -2195,19 +2185,8 @@ class OrgTest(TembaTest):
         self.assertTrue(self.org.has_airtime_transfers())
 
     def test_prometheus(self):
-        # visit as viewer, no prometheus section
-        self.login(self.user)
-        org_home_url = reverse("orgs.org_home")
-        response = self.client.get(org_home_url)
-
-        self.assertNotContains(response, "Prometheus")
-
         # admin can see it though
         self.login(self.admin)
-
-        response = self.client.get(org_home_url)
-        self.assertContains(response, "Prometheus")
-        self.assertContains(response, "Enable Prometheus")
 
         # enable it
         prometheus_url = reverse("orgs.org_prometheus")
@@ -2218,22 +2197,12 @@ class OrgTest(TembaTest):
         prometheus_group = Group.objects.get(name="Prometheus")
         self.assertTrue(APIToken.objects.filter(org=self.org, role=prometheus_group, is_active=True))
 
-        # other admin sees it enabled too
-        self.other_admin = self.create_user("Other Administrator")
-        self.org.administrators.add(self.other_admin)
-        self.login(self.other_admin)
-
-        response = self.client.get(org_home_url)
-        self.assertContains(response, "Prometheus")
-        self.assertContains(response, "Disable Prometheus")
-
         # now disable it
         response = self.client.post(prometheus_url, {}, follow=True)
         self.assertFalse(APIToken.objects.filter(org=self.org, role=prometheus_group, is_active=True))
         self.assertContains(response, "Enable Prometheus")
 
     def test_resthooks(self):
-        home_url = reverse("orgs.org_home")
         resthook_url = reverse("orgs.org_resthooks")
 
         # no hitting this page without auth
@@ -2247,9 +2216,6 @@ class OrgTest(TembaTest):
 
         # shouldn't have any resthooks listed yet
         self.assertFalse(response.context["current_resthooks"])
-
-        response = self.client.get(home_url)
-        self.assertContains(response, "You have <b>no flow events</b> configured.")
 
         # try to create one with name that's too long
         response = self.client.post(resthook_url, {"new_slug": "x" * 100})
@@ -2271,10 +2237,6 @@ class OrgTest(TembaTest):
             [{"field": f"resthook_{mother_reg.id}", "resthook": mother_reg}],
             list(response.context["current_resthooks"]),
         )
-
-        # and summarized on org home page
-        response = self.client.get(home_url)
-        self.assertContains(response, "You have <b>1 flow event</b> configured.")
 
         # let's try to create a repeat, should fail due to duplicate slug
         response = self.client.post(resthook_url, {"new_slug": "Mother-Registration"})
@@ -2300,14 +2262,7 @@ class OrgTest(TembaTest):
     def test_smtp_server(self):
         self.login(self.admin)
 
-        home_url = reverse("orgs.org_home")
         config_url = reverse("orgs.org_smtp_server")
-
-        # orgs without SMTP settings see default from address
-        response = self.client.get(home_url)
-        self.assertContains(response, "Emails sent from flows will be sent from <b>no-reply@temba.io</b>.")
-        self.assertEqual("no-reply@temba.io", response.context["from_email_default"])
-        self.assertEqual(None, response.context["from_email_custom"])
 
         self.assertFalse(self.org.has_smtp_config())
 
@@ -2860,7 +2815,7 @@ class OrgTest(TembaTest):
 
         sub_org.refresh_from_db()
 
-        self.assertEqual(response.url, f"/org/sub_orgs/")
+        self.assertEqual(response.url, "/org/sub_orgs/")
 
         # edit our sub org's details in a spa view
         response = self.client.post(

--- a/temba/orgs/tests.py
+++ b/temba/orgs/tests.py
@@ -2184,24 +2184,6 @@ class OrgTest(TembaTest):
 
         self.assertTrue(self.org.has_airtime_transfers())
 
-    def test_prometheus(self):
-        # admin can see it though
-        self.login(self.admin)
-
-        # enable it
-        prometheus_url = reverse("orgs.org_prometheus")
-        response = self.client.post(prometheus_url, {}, follow=True)
-        self.assertContains(response, "Disable Prometheus")
-
-        # make sure our API token exists
-        prometheus_group = Group.objects.get(name="Prometheus")
-        self.assertTrue(APIToken.objects.filter(org=self.org, role=prometheus_group, is_active=True))
-
-        # now disable it
-        response = self.client.post(prometheus_url, {}, follow=True)
-        self.assertFalse(APIToken.objects.filter(org=self.org, role=prometheus_group, is_active=True))
-        self.assertContains(response, "Enable Prometheus")
-
     def test_resthooks(self):
         resthook_url = reverse("orgs.org_resthooks")
 

--- a/temba/orgs/views.py
+++ b/temba/orgs/views.py
@@ -77,7 +77,7 @@ from temba.utils.http import http_headers
 from temba.utils.timezones import TimeZoneFormField
 from temba.utils.views import ComponentFormMixin, NonAtomicMixin, RequireRecentAuthMixin, SpaMixin
 
-from .models import BackupToken, IntegrationType, Invitation, Org, OrgCache, OrgRole, TopUp, get_stripe_credentials
+from .models import BackupToken, Invitation, Org, OrgCache, OrgRole, TopUp, get_stripe_credentials
 from .tasks import apply_topups_task
 
 # session key for storing a two-factor enabled user's id once we've checked their password

--- a/temba/orgs/views.py
+++ b/temba/orgs/views.py
@@ -3248,15 +3248,6 @@ class OrgCRUDL(SmartCRUDL):
             user = self.request.user
             org = user.get_org()
 
-            # if we are on the topups plan, show our usual credits view
-            if org.plan == settings.TOPUP_PLAN:
-                if self.has_org_perm("orgs.topup_list"):
-                    formax.add_section("topups", reverse("orgs.topup_list"), icon="icon-coins", action="link")
-
-            else:
-                if self.has_org_perm("orgs.org_plan"):  # pragma: needs cover
-                    formax.add_section("plan", reverse("orgs.org_plan"), icon="icon-credit", action="summary")
-
             if self.has_org_perm("channels.channel_update"):
                 # get any channel thats not a delegate
                 channels = Channel.objects.filter(org=org, is_active=True, parent=None).order_by("-role")
@@ -3311,30 +3302,8 @@ class OrgCRUDL(SmartCRUDL):
             if self.has_org_perm("orgs.org_languages"):
                 formax.add_section("languages", reverse("orgs.org_languages"), icon="icon-language")
 
-            if self.has_org_perm("orgs.org_country") and org.get_branding().get("location_support"):
-                formax.add_section("country", reverse("orgs.org_country"), icon="icon-location2")
-
-            if self.has_org_perm("orgs.org_smtp_server"):
-                formax.add_section("email", reverse("orgs.org_smtp_server"), icon="icon-envelop")
-
-            if self.has_org_perm("orgs.org_manage_integrations"):
-                for integration in IntegrationType.get_all():
-                    if integration.is_available_to(user):
-                        integration.management_ui(self.object, formax)
-
             if self.has_org_perm("orgs.org_token"):
                 formax.add_section("token", reverse("orgs.org_token"), icon="icon-cloud-upload", nobutton=True)
-
-            if self.has_org_perm("orgs.org_prometheus"):
-                formax.add_section("prometheus", reverse("orgs.org_prometheus"), icon="icon-prometheus", nobutton=True)
-
-            if self.has_org_perm("orgs.org_resthooks"):
-                formax.add_section(
-                    "resthooks",
-                    reverse("orgs.org_resthooks"),
-                    icon="icon-cloud-lightning",
-                    wide="true",
-                )
 
             if self.has_org_perm("orgs.org_two_factor"):
                 if user.get_settings().two_factor_enabled:
@@ -3345,10 +3314,6 @@ class OrgCRUDL(SmartCRUDL):
                     formax.add_section(
                         "two_factor", reverse("orgs.user_two_factor_enable"), icon="icon-two-factor", action="link"
                     )
-
-            # show globals and archives
-            formax.add_section("globals", reverse("globals.global_list"), icon="icon-global", action="link")
-            formax.add_section("archives", reverse("archives.archive_message"), icon="icon-box", action="link")
 
     class TwilioAccount(ComponentFormMixin, InferOrgMixin, OrgPermsMixin, SmartUpdateView):
         success_message = ""

--- a/templates/flows/flow_list.haml
+++ b/templates/flows/flow_list.haml
@@ -86,6 +86,12 @@
               .mt-3.button-light.block.mt-3(onclick="goto(event)" href="{% url 'request_logs.httplog_webhooks' %}")
                 -trans "Webhook Call Log"
 
+            .mt-3.button-light.block.mt-3(onclick="goto(event)" href="{% url 'globals.global_list' %}")
+              -trans "Globals"
+
+            .mt-3.button-light.block.mt-3(onclick="goto(event)" href="{% url 'archives.archive_run' %}")
+              -trans "Run Archives"
+
         .right
           -if org_has_flows
             .flex.w-full.items-end.mb-4

--- a/templates/msgs/message_box.haml
+++ b/templates/msgs/message_box.haml
@@ -93,6 +93,9 @@
                 %temba-modax{ header:'{% trans "Create Folder" %}', endpoint:"{% url 'msgs.label_create_folder' %}"}
                   .button-light.block.mt-3
                     -trans "Create Folder"
+                
+              .mt-3.button-light.block.mt-3(onclick="goto(event)" href="{% url 'archives.archive_message' %}")
+                -trans "Message Archives"
 
         -if has_messages
           .right


### PR DESCRIPTION
- Org Settings: Simplified the settings page by removing sections for plans, integrations, SMTP, and legacy options.
- Navigation: Relocated "Globals" and "Archives" links to the Flows and Messages sidebars.