### PR TITLE
feat: Add project type update functionality and refactor event handling

### DIFF
--- a/temba/projects/consumers/project_event_consumer.py
+++ b/temba/projects/consumers/project_event_consumer.py
@@ -1,21 +1,21 @@
-import amqp
 from enum import StrEnum
 
+import amqp
 from sentry_sdk import capture_exception
 
 from temba.event_driven.consumers import EDAConsumer
 from temba.event_driven.parsers.json_parser import JSONParser
 from temba.projects.usecases.project_delete import delete_project
 from temba.projects.usecases.project_status_update import update_project_status
-from temba.projects.usecases.project_update import update_project_config
 from temba.projects.usecases.project_type_update import update_project_type
+from temba.projects.usecases.project_update import update_project_config
 
 
 class EventAction(StrEnum):
     DELETED = "deleted"
     UPDATED = "updated"
     STATUS_UPDATED = "status_updated"
-    PROJECT_TYPE_UPDATED = "project_type_updated"
+    PROJECT_TYPE_UPDATED = "project_type_update"
 
 
 class ProjectStatus(StrEnum):
@@ -66,15 +66,21 @@ class ProjectEventConsumer(EDAConsumer):
                 raise ValueError(f"Missing required field: {field}")
 
         action = body.get("action")
-        if action not in EventAction:
-            raise ValueError(f"Invalid action: {action}. Must be one of {list(EventAction)}")
+        try:
+            EventAction(action)
+        except ValueError:
+            allowed = ", ".join(e.value for e in EventAction)
+            raise ValueError(f"Invalid action: {action}. Must be one of: {allowed}") from None
 
         if action == EventAction.STATUS_UPDATED:
             status = body.get("status")
             if not status:
                 raise ValueError("Missing required field 'status' for status_updated action")
-            if status not in ProjectStatus:
-                raise ValueError(f"Invalid status: {status}. Must be one of {list(ProjectStatus)}")
+            try:
+                ProjectStatus(status)
+            except ValueError:
+                allowed = ", ".join(e.value for e in ProjectStatus)
+                raise ValueError(f"Invalid status: {status}. Must be one of: {allowed}") from None
 
     def _process_event(self, project_uuid: str, user_email: str, action: str, body: dict):
         """
@@ -128,7 +134,7 @@ class ProjectEventConsumer(EDAConsumer):
                     )
                 else:
                     print(f"[ProjectEventConsumer] - Project {project_uuid} not found for status update")
-            
+
             elif action == EventAction.PROJECT_TYPE_UPDATED:
                 is_multi_agents = bool(body.get("is_multi_agents"))
                 org = update_project_type(
@@ -136,9 +142,11 @@ class ProjectEventConsumer(EDAConsumer):
                     is_multi_agents=is_multi_agents,
                     user_email=user_email,
                 )
-                
+
                 if org:
-                    print(f"[ProjectEventConsumer] - Successfully updated project '{org.name}' ({project_uuid}) is_multi_agents to {is_multi_agents}")
+                    print(
+                        f"[ProjectEventConsumer] - Successfully updated project '{org.name}' ({project_uuid}) is_multi_agents to {is_multi_agents}"
+                    )
                 else:
                     print(f"[ProjectEventConsumer] - Project {project_uuid} not found for project type update")
             else:

--- a/temba/projects/consumers/project_event_consumer.py
+++ b/temba/projects/consumers/project_event_consumer.py
@@ -1,4 +1,6 @@
 import amqp
+from enum import StrEnum
+
 from sentry_sdk import capture_exception
 
 from temba.event_driven.consumers import EDAConsumer
@@ -6,6 +8,20 @@ from temba.event_driven.parsers.json_parser import JSONParser
 from temba.projects.usecases.project_delete import delete_project
 from temba.projects.usecases.project_status_update import update_project_status
 from temba.projects.usecases.project_update import update_project_config
+from temba.projects.usecases.project_type_update import update_project_type
+
+
+class EventAction(StrEnum):
+    DELETED = "deleted"
+    UPDATED = "updated"
+    STATUS_UPDATED = "status_updated"
+    PROJECT_TYPE_UPDATED = "project_type_updated"
+
+
+class ProjectStatus(StrEnum):
+    ACTIVE = "ACTIVE"
+    IN_TEST = "IN_TEST"
+    INACTIVE = "INACTIVE"
 
 
 class ProjectEventConsumer(EDAConsumer):
@@ -50,16 +66,15 @@ class ProjectEventConsumer(EDAConsumer):
                 raise ValueError(f"Missing required field: {field}")
 
         action = body.get("action")
-        if action not in ["deleted", "updated", "status_updated"]:
-            raise ValueError(f"Invalid action: {action}. Must be 'deleted', 'updated', or 'status_updated'")
+        if action not in EventAction:
+            raise ValueError(f"Invalid action: {action}. Must be one of {list(EventAction)}")
 
-        # Validate status field for status_updated action
-        if action == "status_updated":
+        if action == EventAction.STATUS_UPDATED:
             status = body.get("status")
             if not status:
                 raise ValueError("Missing required field 'status' for status_updated action")
-            if status not in ["ACTIVE", "IN_TEST", "INACTIVE"]:
-                raise ValueError(f"Invalid status: {status}. Must be 'ACTIVE', 'IN_TEST', or 'INACTIVE'")
+            if status not in ProjectStatus:
+                raise ValueError(f"Invalid status: {status}. Must be one of {list(ProjectStatus)}")
 
     def _process_event(self, project_uuid: str, user_email: str, action: str, body: dict):
         """
@@ -72,7 +87,7 @@ class ProjectEventConsumer(EDAConsumer):
             body: Full message body
         """
         try:
-            if action == "deleted":
+            if action == EventAction.DELETED:
                 org = delete_project(
                     project_uuid=project_uuid,
                     user_email=user_email,
@@ -83,7 +98,7 @@ class ProjectEventConsumer(EDAConsumer):
                 else:
                     print(f"[ProjectEventConsumer] - Project {project_uuid} not found for deletion")
 
-            elif action == "updated":
+            elif action == EventAction.UPDATED:
                 org = update_project_config(
                     project_uuid=project_uuid,
                     user_email=user_email,
@@ -98,7 +113,7 @@ class ProjectEventConsumer(EDAConsumer):
                 else:
                     print(f"[ProjectEventConsumer] - Project {project_uuid} not found for update")
 
-            elif action == "status_updated":
+            elif action == EventAction.STATUS_UPDATED:
                 status = body.get("status")
                 org = update_project_status(
                     project_uuid=project_uuid,
@@ -113,7 +128,19 @@ class ProjectEventConsumer(EDAConsumer):
                     )
                 else:
                     print(f"[ProjectEventConsumer] - Project {project_uuid} not found for status update")
-
+            
+            elif action == EventAction.PROJECT_TYPE_UPDATED:
+                is_multi_agents = bool(body.get("is_multi_agents"))
+                org = update_project_type(
+                    project_uuid=project_uuid,
+                    is_multi_agents=is_multi_agents,
+                    user_email=user_email,
+                )
+                
+                if org:
+                    print(f"[ProjectEventConsumer] - Successfully updated project '{org.name}' ({project_uuid}) is_multi_agents to {is_multi_agents}")
+                else:
+                    print(f"[ProjectEventConsumer] - Project {project_uuid} not found for project type update")
             else:
                 raise ValueError(f"Unknown action: {action}")
 

--- a/temba/projects/consumers/tests/test_project_event_consumer.py
+++ b/temba/projects/consumers/tests/test_project_event_consumer.py
@@ -124,6 +124,23 @@ class TestProjectEventConsumer(TembaTest):
         reloaded_org = Org.objects.get(proj_uuid=self.project_uuid)
         self.assertTrue(reloaded_org.is_active)
 
+    def test_consume_project_type_update_action_successfully(self):
+        """Test consuming a project_type_update action message"""
+        body = {
+            "project_uuid": self.project_uuid,
+            "user_email": self.user.email,
+            "action": "project_type_update",
+            "is_multi_agents": True,
+        }
+        message = self._create_mock_message(body)
+
+        self.consumer.consume(message)
+
+        message.channel.basic_ack.assert_called_once_with(message.delivery_tag)
+
+        reloaded_org = Org.objects.get(proj_uuid=self.project_uuid)
+        self.assertTrue(reloaded_org.config.get("is_multi_agents"))
+
     def test_consume_status_updated_to_in_test(self):
         """Test consuming a status_updated action to IN_TEST"""
         self.test_org.is_active = False
@@ -332,7 +349,7 @@ class TestProjectEventConsumer(TembaTest):
 
     def test_validate_message_with_all_valid_actions(self):
         """Test _validate_message with all valid actions"""
-        valid_actions = ["deleted", "updated", "status_updated"]
+        valid_actions = ["deleted", "updated", "status_updated", "project_type_update"]
 
         for action in valid_actions:
             body = {

--- a/temba/projects/consumers/tests/test_project_event_consumer.py
+++ b/temba/projects/consumers/tests/test_project_event_consumer.py
@@ -62,6 +62,25 @@ class TestProjectEventConsumer(TembaTest):
         self.assertEqual(reloaded_org.language, "pt-br")
         self.assertEqual(reloaded_org.timezone, pytz.timezone("America/Sao_Paulo"))
 
+    def test_consume_update_action_when_usecase_returns_none_acknowledges(self):
+        """update_project_config may return None; consumer acks and logs not found."""
+        body = {
+            "project_uuid": self.project_uuid,
+            "user_email": self.user.email,
+            "action": "updated",
+            "name": "Any Name",
+        }
+        message = self._create_mock_message(body)
+
+        with patch(
+            "temba.projects.consumers.project_event_consumer.update_project_config",
+            return_value=None,
+        ):
+            self.consumer.consume(message)
+
+        message.channel.basic_ack.assert_called_once_with(message.delivery_tag)
+        message.channel.basic_reject.assert_not_called()
+
     def test_consume_delete_action_successfully(self):
         """Test consuming a delete action message"""
         body = {
@@ -140,6 +159,25 @@ class TestProjectEventConsumer(TembaTest):
 
         reloaded_org = Org.objects.get(proj_uuid=self.project_uuid)
         self.assertTrue(reloaded_org.config.get("is_multi_agents"))
+
+    def test_consume_project_type_update_when_usecase_returns_none_acknowledges(self):
+        """update_project_type may return None; consumer acks and logs not found."""
+        body = {
+            "project_uuid": self.project_uuid,
+            "user_email": self.user.email,
+            "action": "project_type_update",
+            "is_multi_agents": True,
+        }
+        message = self._create_mock_message(body)
+
+        with patch(
+            "temba.projects.consumers.project_event_consumer.update_project_type",
+            return_value=None,
+        ):
+            self.consumer.consume(message)
+
+        message.channel.basic_ack.assert_called_once_with(message.delivery_tag)
+        message.channel.basic_reject.assert_not_called()
 
     def test_consume_status_updated_to_in_test(self):
         """Test consuming a status_updated action to IN_TEST"""
@@ -384,6 +422,20 @@ class TestProjectEventConsumer(TembaTest):
                 self.consumer._validate_message(body)
             except ValueError:
                 self.fail(f"_validate_message raised ValueError for valid status: {status}")
+
+    def test_process_event_unknown_action_raises_value_error(self):
+        """Unhandled action string hits the final else (not reachable via consume + _validate_message)."""
+        body = {
+            "project_uuid": self.project_uuid,
+            "user_email": self.user.email,
+        }
+        with self.assertRaisesRegex(ValueError, "Unknown action: future_action"):
+            self.consumer._process_event(
+                self.project_uuid,
+                self.user.email,
+                "future_action",
+                body,
+            )
 
     def test_process_event_with_exception_in_usecase_rejects_message(self):
         """Test that exceptions in usecases are properly handled"""

--- a/temba/projects/usecases/project_type_update.py
+++ b/temba/projects/usecases/project_type_update.py
@@ -1,0 +1,58 @@
+import logging
+from typing import Optional
+
+from django.contrib.auth import get_user_model
+from django.utils import timezone
+
+from temba.orgs.models import Org
+
+User = get_user_model()
+
+logger = logging.getLogger(__name__)
+
+
+def get_or_create_user_by_email(email: str) -> tuple:  # pragma: no cover
+    user = User.objects.filter(email=email).first()
+    if user:
+        return user, False
+    return User.objects.get_or_create(email=email, defaults={"username": email})
+
+
+def update_project_type(project_uuid: str, is_multi_agents: bool, user_email: str) -> Optional[Org]:
+    """
+    Update the project (Org) type by setting the is_multi_agents flag in its config.
+
+    Args:
+        project_uuid: UUID of the project (stored in Org.proj_uuid)
+        is_multi_agents: Whether the project is a multi-agent project
+        user_email: Email of the user performing the update
+
+    Returns:
+        The updated Org object, or None if not found
+    """
+    try:
+        org = Org.objects.get(proj_uuid=project_uuid)
+    except Org.DoesNotExist:
+        logger.warning(f"Project with uuid {project_uuid} not found for type update")
+        return None
+
+    if org.config is None:
+        org.config = {}
+
+    if org.config.get("is_multi_agents") == is_multi_agents:
+        logger.info(
+            f"Project '{org.name}' ({project_uuid}) already has is_multi_agents={is_multi_agents}, no update needed"
+        )
+        return org
+
+    org.config["is_multi_agents"] = is_multi_agents
+
+    user, _ = get_or_create_user_by_email(user_email)
+    org.modified_by = user
+    org.modified_on = timezone.now()
+
+    org.save(update_fields=["config", "modified_by", "modified_on"])
+
+    logger.info(f"Project '{org.name}' ({project_uuid}) is_multi_agents set to {is_multi_agents} by {user_email}")
+
+    return org

--- a/temba/projects/usecases/tests/test_project_type_update.py
+++ b/temba/projects/usecases/tests/test_project_type_update.py
@@ -1,4 +1,5 @@
 import uuid
+from unittest.mock import MagicMock, patch
 
 import pytz
 
@@ -76,7 +77,7 @@ class TestUpdateProjectType(TembaTest):
         self.assertEqual(reloaded_org.config["description"], "Test description")
 
     def test_set_is_multi_agents_when_config_is_none(self):
-        """Test setting is_multi_agents when org config is None"""
+        """Persisted NULL config is loaded as {} by JSONAsTextField; update still sets is_multi_agents."""
         org_without_config = Org.objects.create(
             name="Org Without Config",
             timezone=pytz.timezone("Africa/Kigali"),
@@ -100,6 +101,23 @@ class TestUpdateProjectType(TembaTest):
         self.assertIsNotNone(updated_org)
         self.assertIsNotNone(reloaded_org.config)
         self.assertTrue(reloaded_org.config["is_multi_agents"])
+
+    def test_initializes_config_dict_when_config_attribute_is_none(self):
+        """Guards org.config is None (ORM normally deserializes NULL to {} via JSONAsTextField)."""
+        org = MagicMock()
+        org.config = None
+        org.name = "In-memory org"
+
+        with patch.object(Org.objects, "get", return_value=org):
+            result = update_project_type(
+                project_uuid=str(uuid.uuid4()),
+                is_multi_agents=True,
+                user_email=self.user.email,
+            )
+
+        self.assertIs(result, org)
+        self.assertEqual(org.config, {"is_multi_agents": True})
+        org.save.assert_called_once_with(update_fields=["config", "modified_by", "modified_on"])
 
     def test_same_value_does_not_update_modified_on(self):
         """Test that setting is_multi_agents to the same value skips the database update"""

--- a/temba/projects/usecases/tests/test_project_type_update.py
+++ b/temba/projects/usecases/tests/test_project_type_update.py
@@ -1,0 +1,151 @@
+import uuid
+
+import pytz
+
+from django.conf import settings
+from django.contrib.auth import get_user_model
+
+from temba.orgs.models import Org
+from temba.projects.usecases.project_type_update import update_project_type
+from temba.tests.base import TembaTest
+
+User = get_user_model()
+
+
+class TestUpdateProjectType(TembaTest):
+    def setUp(self):
+        super().setUp()
+        self.test_org = Org.objects.create(
+            name="Test Org",
+            timezone=pytz.timezone("Africa/Kigali"),
+            brand=settings.DEFAULT_BRAND,
+            proj_uuid=uuid.uuid4(),
+            created_by=self.user,
+            modified_by=self.user,
+            config={"description": "Test description"},
+            language="en-us",
+            is_active=True,
+        )
+        self.project_uuid = str(self.test_org.proj_uuid)
+
+    def test_set_is_multi_agents_true(self):
+        """Test setting is_multi_agents to True"""
+        updated_org = update_project_type(
+            project_uuid=self.project_uuid,
+            is_multi_agents=True,
+            user_email=self.user.email,
+        )
+
+        reloaded_org = Org.objects.get(proj_uuid=self.project_uuid)
+
+        self.assertIsNotNone(updated_org)
+        self.assertTrue(reloaded_org.config["is_multi_agents"])
+        self.assertEqual(updated_org, reloaded_org)
+        self.assertEqual(reloaded_org.modified_by, self.user)
+
+    def test_set_is_multi_agents_false(self):
+        """Test setting is_multi_agents to False"""
+        self.test_org.config["is_multi_agents"] = True
+        self.test_org.save()
+
+        updated_org = update_project_type(
+            project_uuid=self.project_uuid,
+            is_multi_agents=False,
+            user_email=self.user.email,
+        )
+
+        reloaded_org = Org.objects.get(proj_uuid=self.project_uuid)
+
+        self.assertIsNotNone(updated_org)
+        self.assertFalse(reloaded_org.config["is_multi_agents"])
+        self.assertEqual(updated_org, reloaded_org)
+        self.assertEqual(reloaded_org.modified_by, self.user)
+
+    def test_set_is_multi_agents_preserves_other_config_keys(self):
+        """Test that setting is_multi_agents does not remove other config keys"""
+        updated_org = update_project_type(
+            project_uuid=self.project_uuid,
+            is_multi_agents=True,
+            user_email=self.user.email,
+        )
+
+        reloaded_org = Org.objects.get(proj_uuid=self.project_uuid)
+
+        self.assertIsNotNone(updated_org)
+        self.assertTrue(reloaded_org.config["is_multi_agents"])
+        self.assertEqual(reloaded_org.config["description"], "Test description")
+
+    def test_set_is_multi_agents_when_config_is_none(self):
+        """Test setting is_multi_agents when org config is None"""
+        org_without_config = Org.objects.create(
+            name="Org Without Config",
+            timezone=pytz.timezone("Africa/Kigali"),
+            brand=settings.DEFAULT_BRAND,
+            proj_uuid=uuid.uuid4(),
+            created_by=self.user,
+            modified_by=self.user,
+            config=None,
+            language="en-us",
+        )
+        org_uuid = str(org_without_config.proj_uuid)
+
+        updated_org = update_project_type(
+            project_uuid=org_uuid,
+            is_multi_agents=True,
+            user_email=self.user.email,
+        )
+
+        reloaded_org = Org.objects.get(proj_uuid=org_uuid)
+
+        self.assertIsNotNone(updated_org)
+        self.assertIsNotNone(reloaded_org.config)
+        self.assertTrue(reloaded_org.config["is_multi_agents"])
+
+    def test_same_value_does_not_update_modified_on(self):
+        """Test that setting is_multi_agents to the same value skips the database update"""
+        self.test_org.config["is_multi_agents"] = True
+        self.test_org.save()
+
+        original_modified_on = self.test_org.modified_on
+
+        updated_org = update_project_type(
+            project_uuid=self.project_uuid,
+            is_multi_agents=True,
+            user_email=self.user.email,
+        )
+
+        reloaded_org = Org.objects.get(proj_uuid=self.project_uuid)
+
+        self.assertIsNotNone(updated_org)
+        self.assertTrue(reloaded_org.config["is_multi_agents"])
+        self.assertEqual(reloaded_org.modified_on, original_modified_on)
+
+    def test_update_with_new_user_email(self):
+        """Test that a new user is created when an unknown email is provided"""
+        new_user_email = "typeupdater@example.com"
+
+        updated_org = update_project_type(
+            project_uuid=self.project_uuid,
+            is_multi_agents=True,
+            user_email=new_user_email,
+        )
+
+        new_user = User.objects.get(email=new_user_email)
+        reloaded_org = Org.objects.get(proj_uuid=self.project_uuid)
+
+        self.assertIsNotNone(updated_org)
+        self.assertEqual(new_user.username, new_user_email)
+        self.assertEqual(reloaded_org.modified_by, new_user)
+        self.assertTrue(reloaded_org.config["is_multi_agents"])
+
+    def test_nonexistent_project_returns_none(self):
+        """Test that updating a non-existent project returns None"""
+        fake_uuid = str(uuid.uuid4())
+
+        result = update_project_type(
+            project_uuid=fake_uuid,
+            is_multi_agents=True,
+            user_email=self.user.email,
+        )
+
+        self.assertIsNone(result)


### PR DESCRIPTION
- Introduced `update_project_type` use case to manage project type updates.
- Added `EventAction` and `ProjectStatus` enums for better action and status management in `ProjectEventConsumer`.
- Updated event handling logic to utilize enums for action validation and processing.
- Implemented tests for the new project type update functionality, ensuring correct behavior for various scenarios.