### PR TITLE
feat: Add email field to fallback auto-creation in contact updates

### DIFF
--- a/WENI-CHANGELOG.md
+++ b/WENI-CHANGELOG.md
@@ -1,3 +1,7 @@
+3.71.2
+----------
+* feat: Add email field to fallback auto-creation in contact updates
+
 3.71.1
 ----------
 * Increase batch lenght in WhatsAppbroadcast API

--- a/temba/api/v2/internals/contacts/serializers.py
+++ b/temba/api/v2/internals/contacts/serializers.py
@@ -16,17 +16,18 @@ User = get_user_model()
 logger = logging.getLogger(__name__)
 
 # Keys that update_contacts_fields may auto-create as text user fields when missing (org under field limit).
-FALLBACK_AUTO_CREATE_CONTACT_FIELD_KEYS = frozenset({"segment", "orderform"})
+FALLBACK_AUTO_CREATE_CONTACT_FIELD_KEYS = frozenset({"segment", "orderform", "email"})
 FALLBACK_AUTO_CREATE_CONTACT_FIELD_LABELS = {
     "segment": "segment",
     "orderform": "orderform",
+    "email": "email",
 }
 
 
 def _resolve_contact_field_for_update(org, user, raw_key):
     """
     Resolve a ContactField for PATCH update_contacts_fields. Unknown keys are ignored unless they are
-    segment or orderform: then we create a text field if missing and the org is under its field limit.
+    segment, orderform or email: then we create a text field if missing and the org is under its field limit.
     """
     canonical = raw_key.lower()
     field = ContactField.user_fields.active_for_org(org=org).filter(key=raw_key).first()

--- a/temba/api/v2/internals/contacts/tests.py
+++ b/temba/api/v2/internals/contacts/tests.py
@@ -824,6 +824,31 @@ class UpdateContactFieldsViewTest(TembaTest):
     @mock_mailroom
     @override_settings(INTERNAL_USER_EMAIL="super@user.com")
     @patch.object(LambdaURLValidator, "protected_resource")
+    def test_fallback_creates_email_when_missing(self, mr_mocks, mock_protected_resource):
+        contact = self.create_contact("Email Test", urns=["twitterid:55555"])
+        self.assertFalse(ContactField.user_fields.filter(org=self.org, key="email").exists())
+
+        mock_protected_resource.return_value = Response({"message": "Access granted!"}, status=status.HTTP_200_OK)
+
+        url = "/api/v2/internals/update_contacts_fields"
+        body = {
+            "project": self.org.proj_uuid,
+            "contact_urn": "twitterid:55555",
+            "contact_fields": {"email": "user@example.com"},
+        }
+
+        response = self.client.patch(url, data=body, content_type="application/json")
+
+        self.assertEqual(response.status_code, 200)
+        self.assertTrue(ContactField.user_fields.filter(org=self.org, key="email").exists())
+
+        contact.refresh_from_db()
+        email_f = ContactField.get_by_key(self.org, "email")
+        self.assertEqual(contact.get_field_display(email_f), "user@example.com")
+
+    @mock_mailroom
+    @override_settings(INTERNAL_USER_EMAIL="super@user.com")
+    @patch.object(LambdaURLValidator, "protected_resource")
     def test_fallback_recreates_segment_and_orderform_when_inactive(self, mr_mocks, mock_protected_resource):
         """
         When segment/orderform fields exist but are inactive (is_active=False), the lookup must


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk: small, isolated change to internal contact-field update fallback behavior, with test coverage; main risk is unintentionally creating an `email` user field in orgs that previously ignored that key.
> 
> **Overview**
> `update_contacts_fields` fallback auto-creation now treats `email` like `segment`/`orderform`: when an update includes the `email` key and no active user field exists, the API will auto-create a text `ContactField` (subject to the org field limit) and apply the value.
> 
> Adds a regression test ensuring the `email` field is created and populated when missing.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2d643dc8d02058719d33da2b6baa447dc9c083ee. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->