### PR TITLE
feat: Use JWT authentication on internal first contacts endpoint

### DIFF
--- a/temba/api/v2/internals/msgs/views.py
+++ b/temba/api/v2/internals/msgs/views.py
@@ -197,10 +197,7 @@ class FirstContactsPagination(LimitOffsetPagination):
     max_limit = 1000
 
 
-class InternalFirstContactsView(APIViewMixin, APIView):
-    authentication_classes = [InternalOIDCAuthentication]
-    permission_classes = [IsAuthenticated, CanCommunicateInternally]
-
+class InternalFirstContactsView(JWTAuthMixinRequired, APIViewMixin, APIView):
     def get(self, request, *args, **kwargs):
         project_uuid = request.query_params.get("project_uuid")
 


### PR DESCRIPTION
### What

Switch `InternalFirstContactsView` (`GET /api/v2/internals/messages/first_contacts`) from OIDC (`InternalOIDCAuthentication` + `CanCommunicateInternally`) to the existing `JWTAuthMixinRequired`, the same mixin already used by `MsgStreamView` right above in the same module.

```python
class InternalFirstContactsView(JWTAuthMixinRequired, APIViewMixin, APIView):
    def get(self, request, *args, **kwargs):
        ...
```

The HTTP contract is unchanged: the endpoint still reads `project_uuid`, `channel_uuid`, `after`, and `before` from the query string. Only the auth credential changes — callers must now send `Authorization: Bearer <jwt>` signed with the same key pair already configured in `settings.JWT_PUBLIC_KEY`.

### Why

Aligns the endpoint with the JWT-based inter-module auth standard used across the codebase (`MsgStreamView`, `ChannelAllowedDomainsView`, `ChannelElevenLabsApiKeyView`, `CleanContactsFieldsView`, `ProjectLanguageView`, etc.) and removes the dependency on the OIDC client_credentials flow for this specific call. The companion change in the billing module updates `FlowsRestClient.get_first_incoming_contacts` to sign and send the JWT.

### Tests

The existing `_patch_first_contacts_auth` helper in `temba/api/v2/internals/msgs/tests.py` keeps working: it patches `authentication_classes`/`permission_classes` on the view class, both still exposed via the mixin.

### Deploy notes

- No new key material required — `JWT_PUBLIC_KEY` already pairs with billing's private key.
- This PR must be deployed before billing starts sending JWT on `get_first_incoming_contacts`, otherwise the endpoint would still expect OIDC.

Made with [Cursor](https://cursor.com)