### PR TITLE
fix: restructure FastAPI initialization and improve module imports

### DIFF
--- a/WENI-CHANGELOG.md
+++ b/WENI-CHANGELOG.md
@@ -1,3 +1,7 @@
+3.75.1
+----------
+* fix: Restructure FastAPI initialization and improve module imports
+
 3.75.0
 ----------
 * feat: Add FastAPI server configuration to Docker start script

--- a/temba/fastapi_app/__init__.py
+++ b/temba/fastapi_app/__init__.py
@@ -1,1 +1,16 @@
-# FastAPI prototypes for benchmarking and optional dedicated processes.
+# isort:skip_file
+"""
+FastAPI prototypes for benchmarking and optional dedicated processes.
+
+Importing this package eagerly initializes Django so submodules can import
+ORM/serializers normally at the top of the file. ``django.setup()`` is
+idempotent, so re-running it inside the test runner is a no-op.
+"""
+
+import os
+
+os.environ.setdefault("DJANGO_SETTINGS_MODULE", "temba.settings")
+
+import django  # noqa: E402
+
+django.setup()

--- a/temba/fastapi_app/broadcasts.py
+++ b/temba/fastapi_app/broadcasts.py
@@ -1,21 +1,11 @@
-import os
+from fastapi import APIRouter, Body, Depends, FastAPI, HTTPException, status as http_status
+from fastapi.responses import JSONResponse
+from rest_framework.request import Request
+from rest_framework.test import APIRequestFactory
 
-from fastapi import APIRouter, Body, Depends, FastAPI, HTTPException, status as http_status  # noqa: E402
-from fastapi.responses import JSONResponse  # noqa: E402
-from rest_framework.request import Request  # noqa: E402
-from rest_framework.test import APIRequestFactory  # noqa: E402
-
-import django  # noqa: E402
-
-from temba.api.v2.internals.broadcasts.context import resolve_org_and_user_internal_whatsapp  # noqa: E402
-from temba.api.v2.serializers import WhatsappBroadcastReadSerializer, WhatsappBroadcastWriteSerializer  # noqa: E402
-from temba.fastapi_app.auth import verify_jwt  # noqa: E402
-
-os.environ.setdefault("DJANGO_SETTINGS_MODULE", "temba.settings")
-
-
-django.setup()
-
+from temba.api.v2.internals.broadcasts.context import resolve_org_and_user_internal_whatsapp
+from temba.api.v2.serializers import WhatsappBroadcastReadSerializer, WhatsappBroadcastWriteSerializer
+from temba.fastapi_app.auth import verify_jwt
 
 app = FastAPI(title="Temba WhatsApp broadcasts (prototype)", version="0")
 app_fastapi = APIRouter(prefix="/fastapi")


### PR DESCRIPTION
Updated the FastAPI application initialization in  to eagerly set up Django, allowing submodules to import ORM and serializers correctly. Cleaned up imports in  by removing redundant Django setup code, streamlining the module structure.