### PR TITLE
feat: Update TemplateTranslation to handle category changes

### DIFF
--- a/temba/templates/models.py
+++ b/temba/templates/models.py
@@ -223,6 +223,8 @@ class TemplateTranslation(models.Model):
             body_value = body[:2048] if body is not None else None
             footer_value = footer[:60] if footer is not None else None
 
+            category_changed = existing.template.category != category
+
             if (
                 existing.status != status
                 or existing.content != content
@@ -230,6 +232,7 @@ class TemplateTranslation(models.Model):
                 or existing.language != language
                 or (body is not None and existing.body != body_value)
                 or (footer is not None and existing.footer != footer_value)
+                or category_changed
             ):
                 existing.status = status
                 existing.content = content
@@ -259,7 +262,11 @@ class TemplateTranslation(models.Model):
                 existing.save(update_fields=[*update_fields])
 
                 existing.template.modified_on = timezone.now()
-                existing.template.save(update_fields=["modified_on"])
+                template_update_fields = ["modified_on"]
+                if category_changed:
+                    existing.template.category = category
+                    template_update_fields.append("category")
+                existing.template.save(update_fields=template_update_fields)
 
         return existing
 

--- a/temba/templates/tests.py
+++ b/temba/templates/tests.py
@@ -62,6 +62,70 @@ class TemplateTest(TembaTest):
         # trim them
         TemplateTranslation.trim(self.channel, [tt1])
 
+    def test_get_or_create_updates_category_on_existing_translation(self):
+        tt = TemplateTranslation.get_or_create(
+            self.channel,
+            "hello",
+            "eng",
+            "US",
+            "Hello {{1}}",
+            1,
+            TemplateTranslation.STATUS_PENDING,
+            "1234",
+            "",
+            "UTILITY",
+        )
+        self.assertEqual(tt.template.category, "UTILITY")
+
+        tt_updated = TemplateTranslation.get_or_create(
+            self.channel,
+            "hello",
+            "eng",
+            "US",
+            "Hello {{1}}",
+            1,
+            TemplateTranslation.STATUS_PENDING,
+            "1234",
+            "",
+            "MARKETING",
+        )
+
+        self.assertEqual(tt.id, tt_updated.id)
+        tt_updated.template.refresh_from_db()
+        self.assertEqual(tt_updated.template.category, "MARKETING")
+
+    def test_get_or_create_category_only_change_triggers_update(self):
+        tt = TemplateTranslation.get_or_create(
+            self.channel,
+            "promo",
+            "eng",
+            "US",
+            "Buy now {{1}}",
+            1,
+            TemplateTranslation.STATUS_APPROVED,
+            "cat-only-1",
+            "",
+            "UTILITY",
+        )
+        original_modified_on = tt.template.modified_on
+
+        tt_updated = TemplateTranslation.get_or_create(
+            self.channel,
+            "promo",
+            "eng",
+            "US",
+            "Buy now {{1}}",
+            1,
+            TemplateTranslation.STATUS_APPROVED,
+            "cat-only-1",
+            "",
+            "MARKETING",
+        )
+
+        tt_updated.template.refresh_from_db()
+        self.assertEqual(tt_updated.template.category, "MARKETING")
+        self.assertTrue(tt_updated.template.modified_on > original_modified_on)
+
     def test_get_or_create_updates_body_and_footer(self):
         # create initial translation with body and footer
         tt = TemplateTranslation.get_or_create(

--- a/temba/utils/whatsapp/tests.py
+++ b/temba/utils/whatsapp/tests.py
@@ -197,6 +197,39 @@ class WhatsAppUtilsTest(TembaTest):
         self.assertEqual(TemplateTranslation.STATUS_UNSUPPORTED_LANGUAGE, ct.status)
         self.assertEqual("foo_namespace", ct.namespace)
 
+    def test_update_local_templates_updates_category(self):
+        channel = self.create_channel("WA", "channel", "5678", config={"fb_namespace": "ns"})
+
+        initial_data = [
+            {
+                "name": "order_update",
+                "components": [{"type": "BODY", "text": "Your order {{1}} is ready"}],
+                "language": "en",
+                "status": "APPROVED",
+                "category": "UTILITY",
+                "id": "tmpl-cat-1",
+            },
+        ]
+        update_local_templates(channel, initial_data)
+
+        template = Template.objects.get(org=self.org, name="order_update")
+        self.assertEqual(template.category, "UTILITY")
+
+        updated_data = [
+            {
+                "name": "order_update",
+                "components": [{"type": "BODY", "text": "Your order {{1}} is ready"}],
+                "language": "en",
+                "status": "APPROVED",
+                "category": "MARKETING",
+                "id": "tmpl-cat-1",
+            },
+        ]
+        update_local_templates(channel, updated_data)
+
+        template.refresh_from_db()
+        self.assertEqual(template.category, "MARKETING")
+
     def test_update_local_templates_dialog360(self):
         # no namespace in channel config
         channel = self.create_channel("D3", "channel", "1234", config={})


### PR DESCRIPTION
- Added logic to update the category of a TemplateTranslation when it is modified.
- Enhanced the get_or_create method to trigger updates for category changes.
- Added unit tests to verify category updates on existing translations and ensure correct behavior when only the category is changed.