### PR TITLE
feat: Add internal channels-by-project endpoint for billing entity sync

### DIFF
--- a/temba/api/v2/internals/channels/tests/test_views.py
+++ b/temba/api/v2/internals/channels/tests/test_views.py
@@ -32,9 +32,13 @@ class ChannelProjectViewTest(TembaTest):
     def test_get_channel_projects(self):
         with override_settings(BILLING_FIXED_ACCESS_TOKEN="12345"):
 
-            project = Project.objects.create(name="Test project", created_by=self.user, modified_by=self.user)
+            project = Project.objects.create(
+                name="Test project", created_by=self.user, modified_by=self.user
+            )
             channel = self.create_channel("TG", "Test Channel", "test", org=project.org)
-            channel_wac = self.create_channel("WAC", "Test WAC Channel", "74123456789", org=project.org)
+            channel_wac = self.create_channel(
+                "WAC", "Test WAC Channel", "74123456789", org=project.org
+            )
             channel_wac.config = {
                 "wa_waba_id": "12345678910",
                 "wa_number": "+55 00 900001234",
@@ -60,9 +64,94 @@ class ChannelProjectViewTest(TembaTest):
             self.assertEqual(result.get("project_uuid"), str(project.project_uuid))
 
             self.assertEqual(result_wac.get("channel_uuid"), str(channel_wac.uuid))
-            self.assertEqual(result_wac.get("waba"), str(channel_wac.config.get("wa_waba_id")))
-            self.assertEqual(result_wac.get("phone_number"), str(channel_wac.config.get("wa_number")))
+            self.assertEqual(
+                result_wac.get("waba"), str(channel_wac.config.get("wa_waba_id"))
+            )
+            self.assertEqual(
+                result_wac.get("phone_number"), str(channel_wac.config.get("wa_number"))
+            )
             self.assertEqual(result_wac.get("project_uuid"), str(project.project_uuid))
+
+
+class ChannelsByProjectInternalViewTest(TembaTest):
+    """Service-to-service variant of ``InternalChannelView`` (token-based auth).
+
+    Used by the billing entity-sync cascade to bulk-hydrate every active channel
+    of a project in a single call.
+    """
+
+    def test_request_without_token(self):
+        url = "/api/v2/internals/channels-by-project-internal"
+        response = self.client.get(url)
+
+        self.assertEqual(response.status_code, 403)
+
+    def test_request_with_invalid_token(self):
+        url = "/api/v2/internals/channels-by-project-internal?token=invalidtoken"
+        response = self.client.get(url)
+
+        self.assertEqual(response.status_code, 403)
+
+    def test_request_without_project_uuid(self):
+        with override_settings(BILLING_FIXED_ACCESS_TOKEN="12345"):
+            url = "/api/v2/internals/channels-by-project-internal?token=12345"
+            response = self.client.get(url)
+
+            self.assertEqual(response.status_code, 400)
+
+    def test_returns_active_channels_for_project(self):
+        with override_settings(BILLING_FIXED_ACCESS_TOKEN="12345"):
+            project = Project.objects.create(
+                name="Test project", created_by=self.user, modified_by=self.user
+            )
+            active = self.create_channel(
+                "TG", "Active Channel", "active", org=project.org
+            )
+            wac = self.create_channel(
+                "WAC", "WAC Channel", "74123456789", org=project.org
+            )
+            wac.config = {
+                "wa_waba_id": "waba-1",
+                "wa_number": "+5500900001234",
+                "is_demo": False,
+            }
+            wac.save()
+            inactive = self.create_channel(
+                "TG", "Inactive Channel", "inactive", org=project.org
+            )
+            inactive.is_active = False
+            inactive.save()
+
+            url = f"/api/v2/internals/channels-by-project-internal?token=12345&project_uuid={project.project_uuid}"
+            response = self.client.get(url)
+            data = response.json()
+
+            self.assertEqual(response.status_code, 200)
+            self.assertIn("results", data)
+            uuids = {entry["uuid"] for entry in data["results"]}
+            self.assertIn(str(active.uuid), uuids)
+            self.assertIn(str(wac.uuid), uuids)
+            self.assertNotIn(str(inactive.uuid), uuids)
+
+            wac_entry = next(
+                entry for entry in data["results"] if entry["uuid"] == str(wac.uuid)
+            )
+            self.assertEqual(wac_entry["channel_type"], "WAC")
+            self.assertEqual(wac_entry["waba"], "waba-1")
+            self.assertEqual(wac_entry["phone_number"], "+5500900001234")
+            self.assertFalse(wac_entry["config"]["is_demo"])
+
+    def test_returns_empty_when_project_has_no_channels(self):
+        with override_settings(BILLING_FIXED_ACCESS_TOKEN="12345"):
+            project = Project.objects.create(
+                name="Empty project", created_by=self.user, modified_by=self.user
+            )
+
+            url = f"/api/v2/internals/channels-by-project-internal?token=12345&project_uuid={project.project_uuid}"
+            response = self.client.get(url)
+
+            self.assertEqual(response.status_code, 200)
+            self.assertEqual(response.json(), {"results": []})
 
 
 class PatchedJWTAuthMixin(JWTAuthMockMixin):
@@ -143,7 +232,9 @@ class ChannelElevenLabsApiKeyViewTest(PatchedJWTAuthMixin, TembaTest):
         response = self.client.get(self.url, **self.auth_headers)
 
         self.assertEqual(response.status_code, 400)
-        self.assertEqual(response.json(), {"channel_uuid": ["This field may not be null."]})
+        self.assertEqual(
+            response.json(), {"channel_uuid": ["This field may not be null."]}
+        )
 
     def test_request_with_nonexistent_channel_uuid(self):
         self._set_jwt_payload(channel_uuid=str(uuid.uuid4()))
@@ -162,7 +253,9 @@ class ChannelElevenLabsApiKeyViewTest(PatchedJWTAuthMixin, TembaTest):
         self.assertEqual(response.json(), {"detail": "ElevenLabs API key not found"})
 
     def test_request_channel_with_partial_voice_mode_config(self):
-        channel = self.create_channel("TG", "Test Channel", "test", config={"voice_mode": {"otherProvider": {}}})
+        channel = self.create_channel(
+            "TG", "Test Channel", "test", config={"voice_mode": {"otherProvider": {}}}
+        )
 
         self._set_jwt_payload(channel_uuid=str(channel.uuid))
         response = self.client.get(self.url, **self.auth_headers)
@@ -171,7 +264,9 @@ class ChannelElevenLabsApiKeyViewTest(PatchedJWTAuthMixin, TembaTest):
         self.assertEqual(response.json(), {"detail": "ElevenLabs API key not found"})
 
     def test_request_channel_with_elevenlabs_but_no_api_key(self):
-        channel = self.create_channel("TG", "Test Channel", "test", config={"voice_mode": {"elevenLabs": {}}})
+        channel = self.create_channel(
+            "TG", "Test Channel", "test", config={"voice_mode": {"elevenLabs": {}}}
+        )
 
         self._set_jwt_payload(channel_uuid=str(channel.uuid))
         response = self.client.get(self.url, **self.auth_headers)
@@ -199,8 +294,14 @@ class InternalChannelViewTest(TembaTest):
         super().setUp()
         self.url = "/api/v2/internals/channels-by-project"
 
-    @patch("temba.api.v2.internals.channels.views.InternalChannelView.authentication_classes", [])
-    @patch("temba.api.v2.internals.channels.views.InternalChannelView.permission_classes", [])
+    @patch(
+        "temba.api.v2.internals.channels.views.InternalChannelView.authentication_classes",
+        [],
+    )
+    @patch(
+        "temba.api.v2.internals.channels.views.InternalChannelView.permission_classes",
+        [],
+    )
     def test_missing_project_uuid(self):
         from temba.channels.models import Channel
 
@@ -209,18 +310,32 @@ class InternalChannelViewTest(TembaTest):
         self.assertEqual(response.status_code, 400)
         self.assertEqual(response.json(), {"error": "project_uuid is required"})
 
-    @patch("temba.api.v2.internals.channels.views.InternalChannelView.authentication_classes", [])
-    @patch("temba.api.v2.internals.channels.views.InternalChannelView.permission_classes", [])
+    @patch(
+        "temba.api.v2.internals.channels.views.InternalChannelView.authentication_classes",
+        [],
+    )
+    @patch(
+        "temba.api.v2.internals.channels.views.InternalChannelView.permission_classes",
+        [],
+    )
     def test_project_not_found(self):
         from temba.channels.models import Channel
 
         Channel.objects.all().delete()
-        response = self.client.get(f"{self.url}?project_uuid=00000000-0000-0000-0000-000000000000")
+        response = self.client.get(
+            f"{self.url}?project_uuid=00000000-0000-0000-0000-000000000000"
+        )
         self.assertEqual(response.status_code, 404)
         self.assertEqual(response.json(), {"error": "Project not found"})
 
-    @patch("temba.api.v2.internals.channels.views.InternalChannelView.authentication_classes", [])
-    @patch("temba.api.v2.internals.channels.views.InternalChannelView.permission_classes", [])
+    @patch(
+        "temba.api.v2.internals.channels.views.InternalChannelView.authentication_classes",
+        [],
+    )
+    @patch(
+        "temba.api.v2.internals.channels.views.InternalChannelView.permission_classes",
+        [],
+    )
     def test_no_active_channels(self):
         from temba.channels.models import Channel
 
@@ -229,8 +344,14 @@ class InternalChannelViewTest(TembaTest):
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.json(), {"results": []})
 
-    @patch("temba.api.v2.internals.channels.views.InternalChannelView.authentication_classes", [])
-    @patch("temba.api.v2.internals.channels.views.InternalChannelView.permission_classes", [])
+    @patch(
+        "temba.api.v2.internals.channels.views.InternalChannelView.authentication_classes",
+        [],
+    )
+    @patch(
+        "temba.api.v2.internals.channels.views.InternalChannelView.permission_classes",
+        [],
+    )
     def test_active_channels(self):
         from temba.channels.models import Channel
 
@@ -243,7 +364,11 @@ class InternalChannelViewTest(TembaTest):
             "Test WAC Channel",
             "74123456789",
             org=self.org,
-            config={"wa_waba_id": "12345678910", "wa_number": "+55 00 900001234", "mmlite": True},
+            config={
+                "wa_waba_id": "12345678910",
+                "wa_number": "+55 00 900001234",
+                "mmlite": True,
+            },
         )
         channel_wac.is_active = True
         channel_wac.save()

--- a/temba/api/v2/internals/channels/urls.py
+++ b/temba/api/v2/internals/channels/urls.py
@@ -1,10 +1,31 @@
 from django.urls import path
 
-from .views import ChannelAllowedDomainsView, ChannelElevenLabsApiKeyView, ChannelProjectView, InternalChannelView
+from .views import (
+    ChannelAllowedDomainsView,
+    ChannelElevenLabsApiKeyView,
+    ChannelProjectView,
+    ChannelsByProjectInternalView,
+    InternalChannelView,
+)
 
 urlpatterns = [
     path("channel_projects", ChannelProjectView.as_view(), name="channel_projects"),
-    path("channels-by-project", InternalChannelView.as_view(), name="channels-by-project"),
-    path("channel_allowed_domains", ChannelAllowedDomainsView.as_view(), name="channel_allowed_domains"),
-    path("elevenlabs_api_key", ChannelElevenLabsApiKeyView.as_view(), name="elevenlabs_api_key"),
+    path(
+        "channels-by-project", InternalChannelView.as_view(), name="channels-by-project"
+    ),
+    path(
+        "channels-by-project-internal",
+        ChannelsByProjectInternalView.as_view(),
+        name="channels-by-project-internal",
+    ),
+    path(
+        "channel_allowed_domains",
+        ChannelAllowedDomainsView.as_view(),
+        name="channel_allowed_domains",
+    ),
+    path(
+        "elevenlabs_api_key",
+        ChannelElevenLabsApiKeyView.as_view(),
+        name="elevenlabs_api_key",
+    ),
 ]

--- a/temba/api/v2/internals/channels/views.py
+++ b/temba/api/v2/internals/channels/views.py
@@ -8,7 +8,10 @@ from weni.internal.authenticators import InternalOIDCAuthentication
 from django.conf import settings
 
 from temba.api.auth.jwt import RequiredJWTAuthentication
-from temba.api.v2.internals.channels.serializers import ChannelElevenLabsApiKeySerializer, ChannelProjectSerializer
+from temba.api.v2.internals.channels.serializers import (
+    ChannelElevenLabsApiKeySerializer,
+    ChannelProjectSerializer,
+)
 from temba.api.v2.internals.channels.usecases import GetElevenLabsApiKeyUseCase
 from temba.api.v2.internals.views import APIViewMixin
 from temba.api.v2.permissions import HasValidJWT, IsUserInOrg
@@ -44,9 +47,15 @@ class ChannelProjectView(APIViewMixin, APIView):
                 "project_uuid": str(channel.org.proj_uuid),
             }
             if channel.channel_type == "WAC":
-                channel_data["waba"] = channel.config.get("wa_waba_id") if channel.config.get("wa_waba_id") else ""
+                channel_data["waba"] = (
+                    channel.config.get("wa_waba_id")
+                    if channel.config.get("wa_waba_id")
+                    else ""
+                )
                 channel_data["phone_number"] = (
-                    channel.config.get("wa_number") if channel.config.get("wa_number") else ""
+                    channel.config.get("wa_number")
+                    if channel.config.get("wa_number")
+                    else ""
                 )
             response["results"].append(channel_data)
 
@@ -77,14 +86,69 @@ class InternalChannelView(APIViewMixin, APIView):
                 "name": channel.name,
             }
             if channel.channel_type == "WAC":
-                channel_data["waba"] = channel.config.get("wa_waba_id") if channel.config.get("wa_waba_id") else None
+                channel_data["waba"] = (
+                    channel.config.get("wa_waba_id")
+                    if channel.config.get("wa_waba_id")
+                    else None
+                )
                 channel_data["phone_number"] = (
-                    channel.config.get("wa_number") if channel.config.get("wa_number") else None
+                    channel.config.get("wa_number")
+                    if channel.config.get("wa_number")
+                    else None
                 )
                 channel_data["MMLite"] = True if channel.config.get("mmlite") else False
             response["results"].append(channel_data)
 
         return Response(response)
+
+
+class ChannelsByProjectInternalView(APIViewMixin, APIView):
+    """Service-to-service variant of `InternalChannelView`.
+
+    Authenticates via the shared `BILLING_FIXED_ACCESS_TOKEN` query token
+    (same pattern as `ChannelProjectView`) so that the billing service can
+    bulk-hydrate every channel of a project during entity-sync cascade.
+    """
+
+    def get(self, request: Request):
+        token = request.query_params.get("token")
+        if token is None:
+            raise NotAuthenticated()
+        if token != settings.BILLING_FIXED_ACCESS_TOKEN:
+            raise AuthenticationFailed()
+
+        project_uuid = request.query_params.get("project_uuid")
+        if not project_uuid:
+            return Response({"error": "project_uuid is required"}, status=400)
+
+        channels = (
+            Channel.objects.filter(org__proj_uuid=project_uuid, is_active=True)
+            .select_related("org")
+            .only(
+                "uuid", "channel_type", "name", "config", "is_active", "org__proj_uuid"
+            )
+        )
+
+        results = []
+        for channel in channels:
+            config = channel.config or {}
+            results.append(
+                {
+                    "uuid": str(channel.uuid),
+                    "channel_type": channel.channel_type,
+                    "name": channel.name,
+                    "is_active": channel.is_active,
+                    "waba": config.get("wa_waba_id") or None,
+                    "phone_number": config.get("wa_number") or None,
+                    "config": {
+                        "wa_waba_id": config.get("wa_waba_id"),
+                        "wa_number": config.get("wa_number"),
+                        "is_demo": bool(config.get("is_demo", False)),
+                    },
+                }
+            )
+
+        return Response({"results": results})
 
 
 class ChannelAllowedDomainsView(APIViewMixin, APIView):
@@ -115,7 +179,9 @@ class ChannelElevenLabsApiKeyView(APIViewMixin, APIView):
 
     def get(self, request: Request):
         channel_uuid = getattr(request, "channel_uuid", None)
-        serializer = ChannelElevenLabsApiKeySerializer(data={"channel_uuid": channel_uuid})
+        serializer = ChannelElevenLabsApiKeySerializer(
+            data={"channel_uuid": channel_uuid}
+        )
         serializer.is_valid(raise_exception=True)
 
         usecase = GetElevenLabsApiKeyUseCase()


### PR DESCRIPTION
## What

Adds `GET /api/v2/internals/channels-by-project-internal?project_uuid=…&token=…`, a service-to-service variant of `InternalChannelView` authenticated by `BILLING_FIXED_ACCESS_TOKEN` (same pattern as `ChannelProjectView`).

The response includes every active `Channel` of the project: `uuid`, `channel_type`, `name`, `is_active`, top-level `waba`/`phone_number` for convenience, plus a raw `config` slice (`wa_waba_id`, `wa_number`, `is_demo`) that the consumer needs to decide channel-type normalization (WAC + `is_demo` → WAD).

Includes tests covering: missing/invalid token (403), missing `project_uuid` (400), happy path with mixed `TG`/`WAC` channels (200 with full payload), and empty result when the project has no channels.

## Why

Billing is rolling out a new entity-sync cascade that pre-warms `org -> projects -> channels` from the source of truth in a single fan-out. The existing `InternalChannelView` requires `InternalOIDCAuthentication + IsUserInOrg`, which expects an end-user identity that the billing service doesn't have. Without this endpoint, billing would have to issue one `get_channel_by_uuid` call per channel of the project (N+1) instead of a single bulk call.

Pairs with weni-ai/billing#240, which contains the consuming `FlowsChannelSource.fetch_by_project`.