### PR TITLE
feat(serializers): add validation for direct_send_template_name

### DIFF
--- a/WENI-CHANGELOG.md
+++ b/WENI-CHANGELOG.md
@@ -1,3 +1,7 @@
+3.76.1
+----------
+* feat(serializers): add validation for direct_send_template_name
+
 3.76.0
 ----------
 * feat: Add session field to auto-create contact fields

--- a/temba/api/v2/serializers.py
+++ b/temba/api/v2/serializers.py
@@ -313,6 +313,8 @@ class WhatsappBroadcastWriteSerializer(WriteSerializer):
                 raise serializers.ValidationError("ttl_seconds must be an integer")
             if value["ttl_seconds"] < 0:
                 raise serializers.ValidationError("ttl_seconds must be a non-negative integer")
+        if "direct_send_template_name" in value and not isinstance(value["direct_send_template_name"], str):
+            raise serializers.ValidationError("direct_send_template_name must be a string")
         return value
 
     def validate(self, data):

--- a/temba/api/v2/tests.py
+++ b/temba/api/v2/tests.py
@@ -1515,11 +1515,12 @@ class APITest(TembaTest):
         broadcast = Broadcast.objects.get(id=response.json()["id"])
         self.assertEqual(carousel_msg, broadcast.metadata)
 
-        # send a msg with direct_send and ttl_seconds
+        # send a msg with direct_send, ttl_seconds and direct_send_template_name
         msg_with_options = {
             "text": "Urgent message",
             "direct_send": True,
             "ttl_seconds": 3600,
+            "direct_send_template_name": "Test Template",
         }
         response = self.postJSON(
             url,
@@ -1566,6 +1567,18 @@ class APITest(TembaTest):
             },
         )
         self.assertResponseError(response, "msg", "ttl_seconds must be a non-negative integer")
+
+        # direct_send_template_name must be a string
+        response = self.postJSON(
+            url,
+            None,
+            {
+                "urns": ["whatsapp:5561912345678"],
+                "contacts": [self.joe.uuid],
+                "msg": {"text": "Test", "direct_send_template_name": 1},
+            },
+        )
+        self.assertResponseError(response, "msg", "direct_send_template_name must be a string")
 
         # send a msg with a non whatsapp cloud defined channel
         response = self.postJSON(


### PR DESCRIPTION
### What
Implemented a validation check to ensure that the direct_send_template_name field is a string. Updated tests to cover this new validation scenario.

### Why
This new field is required when we want to use a specific template name in meta