### PR TITLE
feat: match WhatsApp contacts without the Brazilian 9th digit in elastic search

### DIFF
--- a/temba/api/v2/elasticsearch/tests/test_usecases.py
+++ b/temba/api/v2/elasticsearch/tests/test_usecases.py
@@ -110,6 +110,12 @@ class SearchContactsElasticUseCaseTest(TembaTest):
         self.assertIn("previous", result["pagination"]["links"])
         mock_search_cls.assert_called_once_with(using=self.client, index="contacts")
 
+    def test_execute_rejects_invalid_pagination(self):
+        with self.assertRaises(ValueError):
+            self.usecase.execute(org_id=1, page_size=0)
+        with self.assertRaises(ValueError):
+            self.usecase.execute(org_id=1, page_number=0)
+
     def test_build_filters_includes_name_and_number(self):
         number_usecase = Mock()
         number_usecase.execute.return_value = {"nested": "query"}

--- a/temba/api/v2/elasticsearch/tests/test_usecases.py
+++ b/temba/api/v2/elasticsearch/tests/test_usecases.py
@@ -14,29 +14,29 @@ from temba.tests import TembaTest
 
 class GetPaginationLinksTest(TembaTest):
     def test_first_page_with_more_pages(self):
-        links = get_pagination_links("http://test/contacts", 1, 3, 10)
-        self.assertEqual(links, {"next": "http://test/contacts?page_number=2&page_size=10"})
+        links = get_pagination_links("https://test/contacts", 1, 3, 10)
+        self.assertEqual(links, {"next": "https://test/contacts?page_number=2&page_size=10"})
 
     def test_middle_page(self):
-        links = get_pagination_links("http://test/contacts", 2, 3, 10)
+        links = get_pagination_links("https://test/contacts", 2, 3, 10)
         self.assertEqual(
             links,
             {
-                "next": "http://test/contacts?page_number=3&page_size=10",
-                "previous": "http://test/contacts?page_number=1&page_size=10",
+                "next": "https://test/contacts?page_number=3&page_size=10",
+                "previous": "https://test/contacts?page_number=1&page_size=10",
             },
         )
 
     def test_last_page_has_no_next(self):
-        links = get_pagination_links("http://test/contacts", 3, 3, 10)
-        self.assertEqual(links, {"previous": "http://test/contacts?page_number=2&page_size=10"})
+        links = get_pagination_links("https://test/contacts", 3, 3, 10)
+        self.assertEqual(links, {"previous": "https://test/contacts?page_number=2&page_size=10"})
 
     def test_single_page_has_no_links(self):
-        self.assertEqual(get_pagination_links("http://test/contacts", 1, 1, 10), {})
+        self.assertEqual(get_pagination_links("https://test/contacts", 1, 1, 10), {})
 
     def test_preserves_existing_query_params(self):
-        links = get_pagination_links("http://test/contacts?project_uuid=abc", 1, 3, 10)
-        self.assertEqual(links["next"], "http://test/contacts?project_uuid=abc&page_number=2&page_size=10")
+        links = get_pagination_links("https://test/contacts?project_uuid=abc", 1, 3, 10)
+        self.assertEqual(links["next"], "https://test/contacts?project_uuid=abc&page_number=2&page_size=10")
 
 
 class BuildContactNumberQueryUseCaseTest(TembaTest):
@@ -121,7 +121,7 @@ class SearchContactsElasticUseCaseTest(TembaTest):
             name="John",
             page_number=2,
             page_size=10,
-            base_url="http://test/contacts?page=1",
+            base_url="https://test/contacts?page=1",
         )
 
         self.assertEqual(result["results"], [{"name": "John", "uuid": "abc"}])
@@ -189,7 +189,7 @@ class SearchContactsElasticUseCaseTest(TembaTest):
         self.assertEqual(result["pagination"]["total_pages"], 0)
         mock_search.query.assert_called_once()
 
-    @override_settings(ELASTICSEARCH_URL="http://es.test:9200", ELASTICSEARCH_TIMEOUT_REQUEST=15)
+    @override_settings(ELASTICSEARCH_URL="https://es.test:9200", ELASTICSEARCH_TIMEOUT_REQUEST=15)
     @patch("temba.api.v2.elasticsearch.usecases.Elasticsearch")
     @patch("temba.api.v2.elasticsearch.usecases.Search")
     def test_create_client_when_not_injected(self, mock_search_cls, mock_elasticsearch_cls):
@@ -205,7 +205,7 @@ class SearchContactsElasticUseCaseTest(TembaTest):
         usecase = SearchContactsElasticUseCase()
         usecase.execute(org_id=1, name="John")
 
-        mock_elasticsearch_cls.assert_called_once_with("http://es.test:9200", timeout=15)
+        mock_elasticsearch_cls.assert_called_once_with("https://es.test:9200", timeout=15)
 
     def test_build_filters_org_id_only(self):
         filters = self.usecase._build_filters(org_id=42, name=None, number=None)

--- a/temba/api/v2/elasticsearch/tests/test_usecases.py
+++ b/temba/api/v2/elasticsearch/tests/test_usecases.py
@@ -1,5 +1,7 @@
 from unittest.mock import Mock, patch
 
+from django.test import override_settings
+
 from temba.api.v2.elasticsearch.usecases import (
     URNS_PATH,
     URNS_SCHEME,
@@ -24,6 +26,13 @@ class GetPaginationLinksTest(TembaTest):
                 "previous": "http://test/contacts?page_number=1&page_size=10",
             },
         )
+
+    def test_last_page_has_no_next(self):
+        links = get_pagination_links("http://test/contacts", 3, 3, 10)
+        self.assertEqual(links, {"previous": "http://test/contacts?page_number=2&page_size=10"})
+
+    def test_single_page_has_no_links(self):
+        self.assertEqual(get_pagination_links("http://test/contacts", 1, 1, 10), {})
 
     def test_preserves_existing_query_params(self):
         links = get_pagination_links("http://test/contacts?project_uuid=abc", 1, 3, 10)
@@ -73,6 +82,19 @@ class BuildContactNumberQueryUseCaseTest(TembaTest):
 
     def test_empty_number_returns_none(self):
         self.assertIsNone(self.usecase.execute(""))
+        self.assertIsNone(self.usecase.execute("abc"))
+
+    def test_whatsapp_variant_only_path(self):
+        # fragment with 9 prefix generates literal + variant
+        query = self.usecase.execute("99676")
+        bool_query = self._nested_bool(query)
+
+        self.assertEqual(len(bool_query["should"]), 2)
+        self.assertEqual(bool_query["should"][0], {"match_phrase": {URNS_PATH: "99676"}})
+        self.assertEqual(
+            bool_query["should"][1]["bool"]["must"][0],
+            {"match_phrase": {URNS_PATH: "9676"}},
+        )
 
 
 class SearchContactsElasticUseCaseTest(TembaTest):
@@ -115,6 +137,103 @@ class SearchContactsElasticUseCaseTest(TembaTest):
             self.usecase.execute(org_id=1, page_size=0)
         with self.assertRaises(ValueError):
             self.usecase.execute(org_id=1, page_number=0)
+
+    @patch("temba.api.v2.elasticsearch.usecases.Search")
+    def test_execute_first_page_has_no_previous_link(self, mock_search_cls):
+        mock_response = Mock()
+        mock_response.__iter__ = Mock(return_value=iter([]))
+        mock_response.hits.total.value = 5
+
+        mock_search = mock_search_cls.return_value
+        mock_search.query.return_value = mock_search
+        mock_search.__getitem__.return_value = mock_search
+        mock_search.execute.return_value = mock_response
+
+        result = self.usecase.execute(org_id=1, name="John", page_number=1, page_size=10)
+
+        self.assertEqual(result["pagination"]["total_pages"], 1)
+        self.assertNotIn("previous", result["pagination"]["links"])
+        self.assertNotIn("next", result["pagination"]["links"])
+
+    @patch("temba.api.v2.elasticsearch.usecases.Search")
+    def test_execute_last_page_has_no_next_link(self, mock_search_cls):
+        mock_response = Mock()
+        mock_response.__iter__ = Mock(return_value=iter([]))
+        mock_response.hits.total.value = 25
+
+        mock_search = mock_search_cls.return_value
+        mock_search.query.return_value = mock_search
+        mock_search.__getitem__.return_value = mock_search
+        mock_search.execute.return_value = mock_response
+
+        result = self.usecase.execute(org_id=1, name="John", page_number=3, page_size=10)
+
+        self.assertEqual(result["pagination"]["total_pages"], 3)
+        self.assertIn("previous", result["pagination"]["links"])
+        self.assertNotIn("next", result["pagination"]["links"])
+
+    @patch("temba.api.v2.elasticsearch.usecases.Search")
+    def test_execute_number_only(self, mock_search_cls):
+        mock_response = Mock()
+        mock_response.__iter__ = Mock(return_value=iter([]))
+        mock_response.hits.total.value = 0
+
+        mock_search = mock_search_cls.return_value
+        mock_search.query.return_value = mock_search
+        mock_search.__getitem__.return_value = mock_search
+        mock_search.execute.return_value = mock_response
+
+        result = self.usecase.execute(org_id=7, number="84981204567")
+
+        self.assertEqual(result["results"], [])
+        self.assertEqual(result["pagination"]["total_pages"], 0)
+        mock_search.query.assert_called_once()
+
+    @override_settings(ELASTICSEARCH_URL="http://es.test:9200", ELASTICSEARCH_TIMEOUT_REQUEST=15)
+    @patch("temba.api.v2.elasticsearch.usecases.Elasticsearch")
+    @patch("temba.api.v2.elasticsearch.usecases.Search")
+    def test_create_client_when_not_injected(self, mock_search_cls, mock_elasticsearch_cls):
+        mock_response = Mock()
+        mock_response.__iter__ = Mock(return_value=iter([]))
+        mock_response.hits.total.value = 0
+
+        mock_search = mock_search_cls.return_value
+        mock_search.query.return_value = mock_search
+        mock_search.__getitem__.return_value = mock_search
+        mock_search.execute.return_value = mock_response
+
+        usecase = SearchContactsElasticUseCase()
+        usecase.execute(org_id=1, name="John")
+
+        mock_elasticsearch_cls.assert_called_once_with("http://es.test:9200", timeout=15)
+
+    def test_build_filters_org_id_only(self):
+        filters = self.usecase._build_filters(org_id=42, name=None, number=None)
+
+        self.assertEqual(len(filters), 1)
+        self.assertEqual(filters[0].to_dict(), {"match": {"org_id": 42}})
+
+    def test_build_filters_name_only(self):
+        filters = self.usecase._build_filters(org_id=42, name="Ana", number=None)
+
+        self.assertEqual(len(filters), 3)
+        self.assertEqual(filters[1].to_dict(), {"match_phrase": {"name": "Ana"}})
+        self.assertEqual(filters[2].to_dict(), {"exists": {"field": "name"}})
+
+    def test_build_filters_skips_invalid_number_query(self):
+        number_usecase = Mock()
+        number_usecase.execute.return_value = None
+        usecase = SearchContactsElasticUseCase(client=self.client, number_query_usecase=number_usecase)
+
+        filters = usecase._build_filters(org_id=42, name=None, number="abc")
+
+        self.assertEqual(len(filters), 1)
+        number_usecase.execute.assert_called_once_with("abc")
+
+    def test_default_number_query_usecase(self):
+        usecase = SearchContactsElasticUseCase(client=self.client)
+
+        self.assertIsInstance(usecase._number_query_usecase, BuildContactNumberQueryUseCase)
 
     def test_build_filters_includes_name_and_number(self):
         number_usecase = Mock()

--- a/temba/api/v2/elasticsearch/tests/test_usecases.py
+++ b/temba/api/v2/elasticsearch/tests/test_usecases.py
@@ -1,0 +1,124 @@
+from unittest.mock import Mock, patch
+
+from temba.api.v2.elasticsearch.usecases import (
+    URNS_PATH,
+    URNS_SCHEME,
+    BuildContactNumberQueryUseCase,
+    SearchContactsElasticUseCase,
+    get_pagination_links,
+)
+from temba.tests import TembaTest
+
+
+class GetPaginationLinksTest(TembaTest):
+    def test_first_page_with_more_pages(self):
+        links = get_pagination_links("http://test/contacts", 1, 3, 10)
+        self.assertEqual(links, {"next": "http://test/contacts?page_number=2&page_size=10"})
+
+    def test_middle_page(self):
+        links = get_pagination_links("http://test/contacts", 2, 3, 10)
+        self.assertEqual(
+            links,
+            {
+                "next": "http://test/contacts?page_number=3&page_size=10",
+                "previous": "http://test/contacts?page_number=1&page_size=10",
+            },
+        )
+
+    def test_preserves_existing_query_params(self):
+        links = get_pagination_links("http://test/contacts?project_uuid=abc", 1, 3, 10)
+        self.assertEqual(links["next"], "http://test/contacts?project_uuid=abc&page_number=2&page_size=10")
+
+
+class BuildContactNumberQueryUseCaseTest(TembaTest):
+    def setUp(self):
+        super().setUp()
+        self.usecase = BuildContactNumberQueryUseCase()
+
+    def _nested_bool(self, query):
+        return query.to_dict()["nested"]["query"]["bool"]
+
+    def test_literal_only_matches_any_scheme(self):
+        query = self.usecase.execute("558481204567")
+        bool_query = self._nested_bool(query)
+
+        self.assertEqual(len(bool_query["should"]), 1)
+        self.assertEqual(bool_query["should"][0], {"match_phrase": {URNS_PATH: "558481204567"}})
+        self.assertEqual(bool_query["must"], [{"exists": {"field": URNS_PATH}}])
+
+    def test_literal_and_whatsapp_variant(self):
+        query = self.usecase.execute("5584981204567")
+        bool_query = self._nested_bool(query)
+
+        self.assertEqual(len(bool_query["should"]), 2)
+        self.assertEqual(bool_query["should"][0], {"match_phrase": {URNS_PATH: "5584981204567"}})
+        self.assertEqual(
+            bool_query["should"][1],
+            {
+                "bool": {
+                    "must": [
+                        {"match_phrase": {URNS_PATH: "558481204567"}},
+                        {"term": {URNS_SCHEME: "whatsapp"}},
+                    ]
+                }
+            },
+        )
+
+    def test_short_number_still_builds_literal_query(self):
+        query = self.usecase.execute("123")
+        bool_query = self._nested_bool(query)
+
+        self.assertEqual(len(bool_query["should"]), 1)
+        self.assertEqual(bool_query["should"][0], {"match_phrase": {URNS_PATH: "123"}})
+
+    def test_empty_number_returns_none(self):
+        self.assertIsNone(self.usecase.execute(""))
+
+
+class SearchContactsElasticUseCaseTest(TembaTest):
+    def setUp(self):
+        super().setUp()
+        self.client = Mock()
+        self.usecase = SearchContactsElasticUseCase(client=self.client)
+
+    @patch("temba.api.v2.elasticsearch.usecases.Search")
+    def test_execute_returns_paginated_results(self, mock_search_cls):
+        mock_hit = Mock()
+        mock_hit.to_dict.return_value = {"name": "John", "uuid": "abc"}
+        mock_response = Mock()
+        mock_response.__iter__ = Mock(return_value=iter([mock_hit]))
+        mock_response.hits.total.value = 25
+
+        mock_search = mock_search_cls.return_value
+        mock_search.query.return_value = mock_search
+        mock_search.__getitem__.return_value = mock_search
+        mock_search.execute.return_value = mock_response
+
+        result = self.usecase.execute(
+            org_id=1,
+            name="John",
+            page_number=2,
+            page_size=10,
+            base_url="http://test/contacts?page=1",
+        )
+
+        self.assertEqual(result["results"], [{"name": "John", "uuid": "abc"}])
+        self.assertEqual(result["pagination"]["page_number"], 2)
+        self.assertEqual(result["pagination"]["page_size"], 10)
+        self.assertEqual(result["pagination"]["total_pages"], 3)
+        self.assertIn("next", result["pagination"]["links"])
+        self.assertIn("previous", result["pagination"]["links"])
+        mock_search_cls.assert_called_once_with(using=self.client, index="contacts")
+
+    def test_build_filters_includes_name_and_number(self):
+        number_usecase = Mock()
+        number_usecase.execute.return_value = {"nested": "query"}
+        usecase = SearchContactsElasticUseCase(client=self.client, number_query_usecase=number_usecase)
+
+        filters = usecase._build_filters(org_id=42, name="Ana", number="84981204567")
+
+        self.assertEqual(len(filters), 4)
+        self.assertEqual(filters[0].to_dict(), {"match": {"org_id": 42}})
+        self.assertEqual(filters[1].to_dict(), {"match_phrase": {"name": "Ana"}})
+        self.assertEqual(filters[2].to_dict(), {"exists": {"field": "name"}})
+        number_usecase.execute.assert_called_once_with("84981204567")

--- a/temba/api/v2/elasticsearch/usecases.py
+++ b/temba/api/v2/elasticsearch/usecases.py
@@ -83,6 +83,11 @@ class SearchContactsElasticUseCase:
         self._number_query_usecase = number_query_usecase or BuildContactNumberQueryUseCase()
 
     def execute(self, org_id, name=None, number=None, page_number=1, page_size=10, base_url=""):
+        if page_size < 1:
+            raise ValueError("page_size must be at least 1")
+        if page_number < 1:
+            raise ValueError("page_number must be at least 1")
+
         client = self._client or self._create_client()
         filters = self._build_filters(org_id, name, number)
         qs = Q("bool", must=filters)

--- a/temba/api/v2/elasticsearch/usecases.py
+++ b/temba/api/v2/elasticsearch/usecases.py
@@ -1,0 +1,123 @@
+from math import ceil
+from urllib.parse import parse_qsl, urlencode, urlparse, urlunparse
+
+from elasticsearch import Elasticsearch
+from elasticsearch_dsl import Q, Search
+
+from django.conf import settings
+
+from temba.utils.whatsapp.ninth_digit import get_number_search_terms
+
+URNS_PATH = "urns.path"
+URNS_SCHEME = "urns.scheme"
+CONTACTS_INDEX = "contacts"
+
+
+def _append_query_params(base_url, **params):
+    parsed = urlparse(base_url)
+    query = dict(parse_qsl(parsed.query, keep_blank_values=True))
+    query.update({key: str(value) for key, value in params.items()})
+    return urlunparse(parsed._replace(query=urlencode(query)))
+
+
+def get_pagination_links(base_url, page_number, total_pages, page_size):
+    links = {}
+    if page_number < total_pages:
+        links["next"] = _append_query_params(
+            base_url,
+            page_number=page_number + 1,
+            page_size=page_size,
+        )
+    if page_number > 1:
+        links["previous"] = _append_query_params(
+            base_url,
+            page_number=page_number - 1,
+            page_size=page_size,
+        )
+    return links
+
+
+class BuildContactNumberQueryUseCase:
+    """
+    Builds the nested Elasticsearch query for contact number search.
+
+    The literal number matches any URN scheme, while the no-9 variant is
+    restricted to whatsapp URNs (stripping the 9 is a WhatsApp-only rule).
+    Returns None when the input has no digits after sanitization.
+    """
+
+    def execute(self, number: str):
+        terms = get_number_search_terms(number)
+        number_queries = []
+
+        if terms["literal"]:
+            number_queries.append(Q("match_phrase", **{URNS_PATH: terms["literal"]}))
+        if terms["whatsapp_variant"]:
+            number_queries.append(
+                Q(
+                    "bool",
+                    must=[
+                        Q("match_phrase", **{URNS_PATH: terms["whatsapp_variant"]}),
+                        Q("term", **{URNS_SCHEME: "whatsapp"}),
+                    ],
+                )
+            )
+        if not number_queries:
+            return None
+
+        return Q(
+            "nested",
+            path="urns",
+            query=Q(
+                "bool",
+                should=number_queries,
+                minimum_should_match=1,
+                must=[Q("exists", field=URNS_PATH)],
+            ),
+        )
+
+
+class SearchContactsElasticUseCase:
+    def __init__(self, client=None, number_query_usecase=None):
+        self._client = client
+        self._number_query_usecase = number_query_usecase or BuildContactNumberQueryUseCase()
+
+    def execute(self, org_id, name=None, number=None, page_number=1, page_size=10, base_url=""):
+        client = self._client or self._create_client()
+        filters = self._build_filters(org_id, name, number)
+        qs = Q("bool", must=filters)
+
+        from_index = (page_number - 1) * page_size
+        search = Search(using=client, index=CONTACTS_INDEX).query(qs)
+        search = search[from_index : from_index + page_size]
+        response = search.execute()
+
+        results = [hit.to_dict() for hit in response]
+        total_results = response.hits.total.value
+        total_pages = ceil(total_results / page_size)
+
+        return {
+            "results": results,
+            "pagination": {
+                "page_number": page_number,
+                "page_size": page_size,
+                "total_pages": total_pages,
+                "links": get_pagination_links(base_url, page_number, total_pages, page_size),
+            },
+        }
+
+    def _build_filters(self, org_id, name, number):
+        filters = [Q("match", org_id=org_id)]
+        if name:
+            filters.append(Q("match_phrase", name=name))
+            filters.append(Q("exists", field="name"))
+        if number:
+            number_query = self._number_query_usecase.execute(number)
+            if number_query is not None:
+                filters.append(number_query)
+        return filters
+
+    def _create_client(self):
+        base_url = settings.ELASTICSEARCH_URL
+        timeout = int(settings.ELASTICSEARCH_TIMEOUT_REQUEST)
+        return Elasticsearch(f"{base_url}", timeout=timeout)

--- a/temba/api/v2/elasticsearch/views.py
+++ b/temba/api/v2/elasticsearch/views.py
@@ -15,7 +15,7 @@ from django.urls import reverse
 
 from temba.api.v2.elasticsearch.serializers import GetContactsSerializer
 from temba.contacts.models import Contact
-from temba.utils.whatsapp.ninth_digit import get_number_search_variations
+from temba.utils.whatsapp.ninth_digit import get_number_search_terms
 
 
 def get_pagination_links(base_url, page_number, total_pages, page_size):  # pragma: no cover
@@ -66,10 +66,26 @@ class ContactsElasticSearchEndpoint(APIView):
                 filte.append(Q("match_phrase", name=name))
                 filte.append(Q("exists", field="name"))
             if number:
-                number_queries = [
-                    Q("match_phrase", **{"urns.path": variation})
-                    for variation in (get_number_search_variations(number) or [number])
-                ]
+                terms = get_number_search_terms(number)
+
+                # The literal number matches any URN scheme, while the no-9 variant is
+                # restricted to whatsapp URNs (stripping the 9 is a WhatsApp-only rule).
+                number_queries = []
+                if terms["literal"]:
+                    number_queries.append(Q("match_phrase", **{"urns.path": terms["literal"]}))
+                if terms["whatsapp_variant"]:
+                    number_queries.append(
+                        Q(
+                            "bool",
+                            must=[
+                                Q("match_phrase", **{"urns.path": terms["whatsapp_variant"]}),
+                                Q("term", **{"urns.scheme": "whatsapp"}),
+                            ],
+                        )
+                    )
+                if not number_queries:
+                    number_queries.append(Q("match_phrase", **{"urns.path": number}))
+
                 filte.append(
                     Q(
                         "nested",
@@ -78,10 +94,7 @@ class ContactsElasticSearchEndpoint(APIView):
                             "bool",
                             should=number_queries,
                             minimum_should_match=1,
-                            must=[
-                                Q("exists", field="urns.path"),
-                                Q("term", **{"urns.scheme": "whatsapp"}),
-                            ],
+                            must=[Q("exists", field="urns.path")],
                         ),
                     ),
                 )

--- a/temba/api/v2/elasticsearch/views.py
+++ b/temba/api/v2/elasticsearch/views.py
@@ -1,7 +1,3 @@
-from math import ceil
-
-from elasticsearch import Elasticsearch
-from elasticsearch_dsl import Q, Search
 from mozilla_django_oidc.contrib.drf import OIDCAuthentication
 from rest_framework import status
 from rest_framework.permissions import IsAuthenticated
@@ -10,21 +6,11 @@ from rest_framework.response import Response
 from rest_framework.views import APIView
 from weni.internal.models import Project
 
-from django.conf import settings
 from django.urls import reverse
 
 from temba.api.v2.elasticsearch.serializers import GetContactsSerializer
+from temba.api.v2.elasticsearch.usecases import SearchContactsElasticUseCase
 from temba.contacts.models import Contact
-from temba.utils.whatsapp.ninth_digit import get_number_search_terms
-
-
-def get_pagination_links(base_url, page_number, total_pages, page_size):  # pragma: no cover
-    links = {}
-    if page_number < total_pages:
-        links["next"] = f"{base_url}&page_number={page_number + 1}&page_size={page_size}"
-    if page_number > 1:
-        links["previous"] = f"{base_url}&page_number={page_number - 1}&page_size={page_size}"
-    return links
 
 
 class ContactsElasticSearchEndpoint(APIView):
@@ -47,84 +33,41 @@ class ContactsElasticSearchEndpoint(APIView):
         params = request.query_params
         project_uuid = params.get("project_uuid")
 
-        project = Project.objects.get(project_uuid=project_uuid)
+        try:
+            project = Project.objects.get(project_uuid=project_uuid)
+        except Project.DoesNotExist:
+            return Response({"error": "Project not found"}, status=status.HTTP_404_NOT_FOUND)
+
         if not project.get_users().filter(id=request.user.id).exists():
             return Response(status=status.HTTP_401_UNAUTHORIZED)
-
-        org_id = project.org.id
 
         name = params.get("name")
         number = params.get("number", "")
 
         if name or number:
-            base_url = settings.ELASTICSEARCH_URL
-            timeout = int(settings.ELASTICSEARCH_TIMEOUT_REQUEST)
-            client = Elasticsearch(f"{base_url}", timeout=timeout)
-            filte = [Q("match", org_id=org_id)]
-            index = "contacts"
-            if name:
-                filte.append(Q("match_phrase", name=name))
-                filte.append(Q("exists", field="name"))
-            if number:
-                terms = get_number_search_terms(number)
+            try:
+                page_number = int(params.get("page_number", 1))
+                page_size = int(params.get("page_size", 10))
+            except (TypeError, ValueError):
+                return Response(
+                    {"error": "Invalid pagination parameters"},
+                    status=status.HTTP_400_BAD_REQUEST,
+                )
 
-                # The literal number matches any URN scheme, while the no-9 variant is
-                # restricted to whatsapp URNs (stripping the 9 is a WhatsApp-only rule).
-                number_queries = []
-                if terms["literal"]:
-                    number_queries.append(Q("match_phrase", **{"urns.path": terms["literal"]}))
-                if terms["whatsapp_variant"]:
-                    number_queries.append(
-                        Q(
-                            "bool",
-                            must=[
-                                Q("match_phrase", **{"urns.path": terms["whatsapp_variant"]}),
-                                Q("term", **{"urns.scheme": "whatsapp"}),
-                            ],
-                        )
-                    )
-                if number_queries:
-                    filte.append(
-                        Q(
-                            "nested",
-                            path="urns",
-                            query=Q(
-                                "bool",
-                                should=number_queries,
-                                minimum_should_match=1,
-                                must=[Q("exists", field="urns.path")],
-                            ),
-                        ),
-                    )
-            qs = Q("bool", must=filte)
+            if page_number < 1 or page_size < 1:
+                return Response(
+                    {"error": "Invalid pagination parameters"},
+                    status=status.HTTP_400_BAD_REQUEST,
+                )
 
-            page_number = int(params.get("page_number", 1))
-            page_size = int(params.get("page_size", 10))
-
-            from_index = (page_number - 1) * page_size
-
-            search = Search(using=client, index=index).query(qs)
-            search = search[from_index : from_index + page_size]
-            response = search.execute()
-
-            results = [hit.to_dict() for hit in response]
-
-            total_results = response.hits.total.value
-            total_pages = ceil(total_results / page_size)
-
-            new_url = request.build_absolute_uri()
-            pagination_links = get_pagination_links(new_url, page_number, total_pages, page_size)
-
-            data = {
-                "results": results,
-                "pagination": {
-                    "page_number": page_number,
-                    "page_size": page_size,
-                    "total_pages": total_pages,
-                    "links": pagination_links,
-                },
-            }
-
+            data = SearchContactsElasticUseCase().execute(
+                org_id=project.org.id,
+                name=name,
+                number=number,
+                page_number=page_number,
+                page_size=page_size,
+                base_url=request.build_absolute_uri(),
+            )
             return Response(data, status=status.HTTP_200_OK)
 
         queryset = Contact.objects.filter(org=project.org).order_by("-modified_on")[:10]

--- a/temba/api/v2/elasticsearch/views.py
+++ b/temba/api/v2/elasticsearch/views.py
@@ -15,6 +15,7 @@ from django.urls import reverse
 
 from temba.api.v2.elasticsearch.serializers import GetContactsSerializer
 from temba.contacts.models import Contact
+from temba.utils.whatsapp.ninth_digit import get_number_search_variations
 
 
 def get_pagination_links(base_url, page_number, total_pages, page_size):  # pragma: no cover
@@ -65,18 +66,21 @@ class ContactsElasticSearchEndpoint(APIView):
                 filte.append(Q("match_phrase", name=name))
                 filte.append(Q("exists", field="name"))
             if number:
+                number_queries = [
+                    Q("match_phrase", **{"urns.path": variation})
+                    for variation in (get_number_search_variations(number) or [number])
+                ]
                 filte.append(
                     Q(
                         "nested",
                         path="urns",
                         query=Q(
                             "bool",
+                            should=number_queries,
+                            minimum_should_match=1,
                             must=[
-                                Q(
-                                    "match_phrase",
-                                    **{"urns.path": number},
-                                ),
                                 Q("exists", field="urns.path"),
+                                Q("term", **{"urns.scheme": "whatsapp"}),
                             ],
                         ),
                     ),
@@ -88,17 +92,13 @@ class ContactsElasticSearchEndpoint(APIView):
 
             from_index = (page_number - 1) * page_size
 
-            contacts = Search(using=client, index=index).query(qs)
-            response = list(contacts.scan())
-
-            for _ in range(from_index):
-                next(response, None)
+            search = Search(using=client, index=index).query(qs)
+            search = search[from_index : from_index + page_size]
+            response = search.execute()
 
             results = [hit.to_dict() for hit in response]
 
-            results = results[:page_size]
-
-            total_results = len(results)
+            total_results = response.hits.total.value
             total_pages = ceil(total_results / page_size)
 
             new_url = request.build_absolute_uri()

--- a/temba/api/v2/elasticsearch/views.py
+++ b/temba/api/v2/elasticsearch/views.py
@@ -83,21 +83,19 @@ class ContactsElasticSearchEndpoint(APIView):
                             ],
                         )
                     )
-                if not number_queries:
-                    number_queries.append(Q("match_phrase", **{"urns.path": number}))
-
-                filte.append(
-                    Q(
-                        "nested",
-                        path="urns",
-                        query=Q(
-                            "bool",
-                            should=number_queries,
-                            minimum_should_match=1,
-                            must=[Q("exists", field="urns.path")],
+                if number_queries:
+                    filte.append(
+                        Q(
+                            "nested",
+                            path="urns",
+                            query=Q(
+                                "bool",
+                                should=number_queries,
+                                minimum_should_match=1,
+                                must=[Q("exists", field="urns.path")],
+                            ),
                         ),
-                    ),
-                )
+                    )
             qs = Q("bool", must=filte)
 
             page_number = int(params.get("page_number", 1))

--- a/temba/settings_common.py
+++ b/temba/settings_common.py
@@ -1445,6 +1445,13 @@ MACHINE_HOSTNAME = socket.gethostname().split(".")[0]
 ELASTICSEARCH_URL = os.environ.get("ELASTICSEARCH_URL", "http://localhost:9200")
 ELASTICSEARCH_TIMEOUT_REQUEST = os.environ.get("ELASTICSEARCH_TIMEOUT_REQUEST", default=10)
 
+# Contact number search (Brazilian 9th digit) configuration.
+# CONTACT_SEARCH_MIN_VARIANT_LEN: minimum digits the no-9 variant must keep to be searched,
+# avoiding overly broad short fragments (e.g. "9676" -> "676").
+# CONTACT_SEARCH_MIN_TERM_LEN: minimum digits a term needs to match the trigram index.
+CONTACT_SEARCH_MIN_VARIANT_LEN = int(os.environ.get("CONTACT_SEARCH_MIN_VARIANT_LEN", default=4))
+CONTACT_SEARCH_MIN_TERM_LEN = int(os.environ.get("CONTACT_SEARCH_MIN_TERM_LEN", default=3))
+
 # SextenX url
 SENTENX_URL = os.environ.get("SENTENX_URL", default="")
 

--- a/temba/settings_common.py
+++ b/temba/settings_common.py
@@ -1448,9 +1448,7 @@ ELASTICSEARCH_TIMEOUT_REQUEST = os.environ.get("ELASTICSEARCH_TIMEOUT_REQUEST", 
 # Contact number search (Brazilian 9th digit) configuration.
 # CONTACT_SEARCH_MIN_VARIANT_LEN: minimum digits the no-9 variant must keep to be searched,
 # avoiding overly broad short fragments (e.g. "9676" -> "676").
-# CONTACT_SEARCH_MIN_TERM_LEN: minimum digits a term needs to match the trigram index.
 CONTACT_SEARCH_MIN_VARIANT_LEN = int(os.environ.get("CONTACT_SEARCH_MIN_VARIANT_LEN", default=4))
-CONTACT_SEARCH_MIN_TERM_LEN = int(os.environ.get("CONTACT_SEARCH_MIN_TERM_LEN", default=3))
 
 # SextenX url
 SENTENX_URL = os.environ.get("SENTENX_URL", default="")

--- a/temba/utils/whatsapp/ninth_digit.py
+++ b/temba/utils/whatsapp/ninth_digit.py
@@ -1,33 +1,67 @@
 import re
 
-# The generated variant (without the 9th digit) must keep at least this many digits.
-# 4 keeps "99676" -> "9676" working while blocking "9676" -> "676", which matched
-# thousands of unrelated contacts in production benchmarks.
-MIN_VARIANT_LEN = 4
+from django.conf import settings
+
+# Fallback defaults, used only when the matching setting is not defined.
+# CONTACT_SEARCH_MIN_VARIANT_LEN keeps "99676" -> "9676" working while blocking
+# "9676" -> "676", which matched thousands of unrelated contacts in production.
+# CONTACT_SEARCH_MIN_TERM_LEN mirrors the trigram analyzer minimum (3 chars).
+DEFAULT_MIN_VARIANT_LEN = 4
+DEFAULT_MIN_TERM_LEN = 3
 
 
-def get_number_search_variations(number: str) -> list:
+def _min_variant_len() -> int:
+    return getattr(settings, "CONTACT_SEARCH_MIN_VARIANT_LEN", DEFAULT_MIN_VARIANT_LEN)
+
+
+def _min_term_len() -> int:
+    return getattr(settings, "CONTACT_SEARCH_MIN_TERM_LEN", DEFAULT_MIN_TERM_LEN)
+
+
+def get_ninth_digit_variant(number: str):
     """
-    Returns the number plus its variant without the Brazilian extra 9th digit.
+    Returns the number without the Brazilian extra 9th digit, or None when it does
+    not apply.
 
     Only the no-9 variant is generated because the trigram index already covers the
     opposite direction (typed without 9 -> contact stored with 9). The variant is
-    only added when it keeps at least MIN_VARIANT_LEN digits, to avoid overly broad
-    short fragments.
+    only returned when it keeps at least CONTACT_SEARCH_MIN_VARIANT_LEN digits, to
+    avoid overly broad short fragments.
     """
     digits = re.sub(r"\D", "", number)
-    variations = [digits]
 
-    stripped = None
     if digits.startswith("55") and len(digits) >= 5 and digits[4] == "9":
         stripped = digits[:4] + digits[5:]
     elif len(digits) == 11 and digits[2] == "9":
         stripped = digits[:2] + digits[3:]
     elif digits.startswith("9"):
         stripped = digits[1:]
+    else:
+        return None
 
-    if stripped and len(stripped) >= MIN_VARIANT_LEN:
-        variations.append(stripped)
+    if len(stripped) < _min_variant_len() or stripped == digits:
+        return None
 
-    seen = set()
-    return [v for v in variations if len(v) >= 3 and not (v in seen or seen.add(v))]
+    return stripped
+
+
+def get_number_search_terms(number: str) -> dict:
+    """
+    Splits a typed number into the terms used by the contacts search query.
+
+    - "literal": the typed digits, searched across all URN schemes. Empty when it
+      has fewer than CONTACT_SEARCH_MIN_TERM_LEN digits, since the trigram analyzer
+      matches nothing below that.
+    - "whatsapp_variant": the number without the Brazilian extra 9th digit, searched
+      only within whatsapp URNs because stripping the 9 is a WhatsApp-specific rule.
+      None when it does not apply or equals the literal.
+    """
+    digits = re.sub(r"\D", "", number)
+
+    literal = digits if len(digits) >= _min_term_len() else ""
+
+    variant = get_ninth_digit_variant(digits)
+    if variant == literal:
+        variant = None
+
+    return {"literal": literal, "whatsapp_variant": variant}

--- a/temba/utils/whatsapp/ninth_digit.py
+++ b/temba/utils/whatsapp/ninth_digit.py
@@ -1,0 +1,33 @@
+import re
+
+# The generated variant (without the 9th digit) must keep at least this many digits.
+# 4 keeps "99676" -> "9676" working while blocking "9676" -> "676", which matched
+# thousands of unrelated contacts in production benchmarks.
+MIN_VARIANT_LEN = 4
+
+
+def get_number_search_variations(number: str) -> list:
+    """
+    Returns the number plus its variant without the Brazilian extra 9th digit.
+
+    Only the no-9 variant is generated because the trigram index already covers the
+    opposite direction (typed without 9 -> contact stored with 9). The variant is
+    only added when it keeps at least MIN_VARIANT_LEN digits, to avoid overly broad
+    short fragments.
+    """
+    digits = re.sub(r"\D", "", number)
+    variations = [digits]
+
+    stripped = None
+    if digits.startswith("55") and len(digits) >= 5 and digits[4] == "9":
+        stripped = digits[:4] + digits[5:]
+    elif len(digits) == 11 and digits[2] == "9":
+        stripped = digits[:2] + digits[3:]
+    elif digits.startswith("9"):
+        stripped = digits[1:]
+
+    if stripped and len(stripped) >= MIN_VARIANT_LEN:
+        variations.append(stripped)
+
+    seen = set()
+    return [v for v in variations if len(v) >= 3 and not (v in seen or seen.add(v))]

--- a/temba/utils/whatsapp/ninth_digit.py
+++ b/temba/utils/whatsapp/ninth_digit.py
@@ -2,20 +2,14 @@ import re
 
 from django.conf import settings
 
-# Fallback defaults, used only when the matching setting is not defined.
-# CONTACT_SEARCH_MIN_VARIANT_LEN keeps "99676" -> "9676" working while blocking
-# "9676" -> "676", which matched thousands of unrelated contacts in production.
-# CONTACT_SEARCH_MIN_TERM_LEN mirrors the trigram analyzer minimum (3 chars).
+# Fallback default, used only when CONTACT_SEARCH_MIN_VARIANT_LEN is not defined.
+# Keeps "99676" -> "9676" working while blocking "9676" -> "676", which matched
+# thousands of unrelated contacts in production benchmarks.
 DEFAULT_MIN_VARIANT_LEN = 4
-DEFAULT_MIN_TERM_LEN = 3
 
 
 def _min_variant_len() -> int:
     return getattr(settings, "CONTACT_SEARCH_MIN_VARIANT_LEN", DEFAULT_MIN_VARIANT_LEN)
-
-
-def _min_term_len() -> int:
-    return getattr(settings, "CONTACT_SEARCH_MIN_TERM_LEN", DEFAULT_MIN_TERM_LEN)
 
 
 def get_ninth_digit_variant(number: str):
@@ -49,19 +43,12 @@ def get_number_search_terms(number: str) -> dict:
     """
     Splits a typed number into the terms used by the contacts search query.
 
-    - "literal": the typed digits, searched across all URN schemes. Empty when it
-      has fewer than CONTACT_SEARCH_MIN_TERM_LEN digits, since the trigram analyzer
-      matches nothing below that.
+    - "literal": sanitized digits, searched across all URN schemes.
     - "whatsapp_variant": the number without the Brazilian extra 9th digit, searched
       only within whatsapp URNs because stripping the 9 is a WhatsApp-specific rule.
-      None when it does not apply or equals the literal.
+      None when it does not apply.
     """
     digits = re.sub(r"\D", "", number)
-
-    literal = digits if len(digits) >= _min_term_len() else ""
-
     variant = get_ninth_digit_variant(digits)
-    if variant == literal:
-        variant = None
 
-    return {"literal": literal, "whatsapp_variant": variant}
+    return {"literal": digits, "whatsapp_variant": variant}

--- a/temba/utils/whatsapp/tests.py
+++ b/temba/utils/whatsapp/tests.py
@@ -688,13 +688,6 @@ class NinthDigitVariationsTest(TembaTest):
             {"literal": "558481204567", "whatsapp_variant": None},
         )
 
-    def test_input_shorter_than_trigram_minimum(self):
-        # below 3 digits the trigram analyzer matches nothing
-        self.assertEqual(
-            get_number_search_terms("12"),
-            {"literal": "", "whatsapp_variant": None},
-        )
-
     def test_non_digit_characters_are_stripped(self):
         self.assertEqual(
             get_number_search_terms("+55 84 98120-4567"),
@@ -709,9 +702,7 @@ class NinthDigitVariationsTest(TembaTest):
         self.assertIsNone(get_ninth_digit_variant("558481204567"))
 
     def test_uses_default_settings(self):
-        # defaults: variant floor 4, term floor 3
         self.assertEqual(settings.CONTACT_SEARCH_MIN_VARIANT_LEN, 4)
-        self.assertEqual(settings.CONTACT_SEARCH_MIN_TERM_LEN, 3)
 
     @override_settings(CONTACT_SEARCH_MIN_VARIANT_LEN=5)
     def test_variant_floor_is_configurable(self):
@@ -733,12 +724,4 @@ class NinthDigitVariationsTest(TembaTest):
         self.assertEqual(
             get_number_search_terms("9676"),
             {"literal": "9676", "whatsapp_variant": "676"},
-        )
-
-    @override_settings(CONTACT_SEARCH_MIN_TERM_LEN=5)
-    def test_term_floor_is_configurable(self):
-        # with term floor 5, a 4-digit literal is dropped
-        self.assertEqual(
-            get_number_search_terms("9676"),
-            {"literal": "", "whatsapp_variant": None},
         )

--- a/temba/utils/whatsapp/tests.py
+++ b/temba/utils/whatsapp/tests.py
@@ -20,6 +20,7 @@ from temba.tests.requests import MockResponse
 from temba.wpp_products.models import Catalog, Product
 
 from . import update_api_version
+from .ninth_digit import get_number_search_variations
 from .tasks import (
     _calculate_variable_count,
     refresh_whatsapp_catalog_and_products,
@@ -648,3 +649,44 @@ class SentenxTestCase(TembaTest):
             sent_trim_products_to_sentenx(self.catalog, self.products)
 
         self.assertEqual(str(context.exception), "Not found SENTENX_URL")
+
+
+class NinthDigitVariationsTest(TembaTest):
+    def test_full_number_with_country_code(self):
+        # DDI 55 + DDD + 9 + 8 digits -> also search without the 9th digit
+        self.assertEqual(
+            get_number_search_variations("5584981204567"),
+            ["5584981204567", "558481204567"],
+        )
+
+    def test_full_number_with_ddd(self):
+        # DDD + 9 + 8 digits (11 digits) -> also search without the 9th digit
+        self.assertEqual(
+            get_number_search_variations("84981204567"),
+            ["84981204567", "8481204567"],
+        )
+
+    def test_fragment_starting_with_nine(self):
+        # fragment long enough that the stripped variant keeps >= 4 digits
+        self.assertEqual(
+            get_number_search_variations("99676"),
+            ["99676", "9676"],
+        )
+
+    def test_short_fragment_does_not_generate_broad_variant(self):
+        # "9676" -> "676" has only 3 digits, so it must not be added
+        self.assertEqual(get_number_search_variations("9676"), ["9676"])
+
+    def test_number_without_ninth_digit_has_no_variant(self):
+        # already without the extra 9 -> nothing to strip
+        self.assertEqual(get_number_search_variations("558481204567"), ["558481204567"])
+
+    def test_input_shorter_than_trigram_minimum(self):
+        # below 3 digits the trigram analyzer matches nothing
+        self.assertEqual(get_number_search_variations("12"), [])
+
+    def test_non_digit_characters_are_stripped(self):
+        self.assertEqual(
+            get_number_search_variations("+55 84 98120-4567"),
+            ["5584981204567", "558481204567"],
+        )

--- a/temba/utils/whatsapp/tests.py
+++ b/temba/utils/whatsapp/tests.py
@@ -4,6 +4,7 @@ import requests
 from django_redis import get_redis_connection
 
 from django.conf import settings
+from django.test import override_settings
 from django.utils import timezone
 
 from temba.channels.models import Channel
@@ -20,7 +21,7 @@ from temba.tests.requests import MockResponse
 from temba.wpp_products.models import Catalog, Product
 
 from . import update_api_version
-from .ninth_digit import get_number_search_variations
+from .ninth_digit import get_ninth_digit_variant, get_number_search_terms
 from .tasks import (
     _calculate_variable_count,
     refresh_whatsapp_catalog_and_products,
@@ -653,40 +654,91 @@ class SentenxTestCase(TembaTest):
 
 class NinthDigitVariationsTest(TembaTest):
     def test_full_number_with_country_code(self):
-        # DDI 55 + DDD + 9 + 8 digits -> also search without the 9th digit
+        # DDI 55 + DDD + 9 + 8 digits -> literal (any scheme) + no-9 variant (whatsapp)
         self.assertEqual(
-            get_number_search_variations("5584981204567"),
-            ["5584981204567", "558481204567"],
+            get_number_search_terms("5584981204567"),
+            {"literal": "5584981204567", "whatsapp_variant": "558481204567"},
         )
 
     def test_full_number_with_ddd(self):
-        # DDD + 9 + 8 digits (11 digits) -> also search without the 9th digit
+        # DDD + 9 + 8 digits (11 digits) -> literal + no-9 variant
         self.assertEqual(
-            get_number_search_variations("84981204567"),
-            ["84981204567", "8481204567"],
+            get_number_search_terms("84981204567"),
+            {"literal": "84981204567", "whatsapp_variant": "8481204567"},
         )
 
     def test_fragment_starting_with_nine(self):
         # fragment long enough that the stripped variant keeps >= 4 digits
         self.assertEqual(
-            get_number_search_variations("99676"),
-            ["99676", "9676"],
+            get_number_search_terms("99676"),
+            {"literal": "99676", "whatsapp_variant": "9676"},
         )
 
     def test_short_fragment_does_not_generate_broad_variant(self):
-        # "9676" -> "676" has only 3 digits, so it must not be added
-        self.assertEqual(get_number_search_variations("9676"), ["9676"])
+        # "9676" -> "676" has only 3 digits, so the variant must not be generated
+        self.assertEqual(
+            get_number_search_terms("9676"),
+            {"literal": "9676", "whatsapp_variant": None},
+        )
 
     def test_number_without_ninth_digit_has_no_variant(self):
         # already without the extra 9 -> nothing to strip
-        self.assertEqual(get_number_search_variations("558481204567"), ["558481204567"])
+        self.assertEqual(
+            get_number_search_terms("558481204567"),
+            {"literal": "558481204567", "whatsapp_variant": None},
+        )
 
     def test_input_shorter_than_trigram_minimum(self):
         # below 3 digits the trigram analyzer matches nothing
-        self.assertEqual(get_number_search_variations("12"), [])
+        self.assertEqual(
+            get_number_search_terms("12"),
+            {"literal": "", "whatsapp_variant": None},
+        )
 
     def test_non_digit_characters_are_stripped(self):
         self.assertEqual(
-            get_number_search_variations("+55 84 98120-4567"),
-            ["5584981204567", "558481204567"],
+            get_number_search_terms("+55 84 98120-4567"),
+            {"literal": "5584981204567", "whatsapp_variant": "558481204567"},
+        )
+
+    def test_ninth_digit_variant_helper(self):
+        self.assertEqual(get_ninth_digit_variant("5584981204567"), "558481204567")
+        self.assertEqual(get_ninth_digit_variant("84981204567"), "8481204567")
+        self.assertEqual(get_ninth_digit_variant("99676"), "9676")
+        self.assertIsNone(get_ninth_digit_variant("9676"))
+        self.assertIsNone(get_ninth_digit_variant("558481204567"))
+
+    def test_uses_default_settings(self):
+        # defaults: variant floor 4, term floor 3
+        self.assertEqual(settings.CONTACT_SEARCH_MIN_VARIANT_LEN, 4)
+        self.assertEqual(settings.CONTACT_SEARCH_MIN_TERM_LEN, 3)
+
+    @override_settings(CONTACT_SEARCH_MIN_VARIANT_LEN=5)
+    def test_variant_floor_is_configurable(self):
+        # with floor 5, "99676" -> "9676" (4 digits) is now too short for the variant
+        self.assertEqual(
+            get_number_search_terms("99676"),
+            {"literal": "99676", "whatsapp_variant": None},
+        )
+        self.assertIsNone(get_ninth_digit_variant("99676"))
+        # a longer number still produces the variant
+        self.assertEqual(
+            get_number_search_terms("84981204567"),
+            {"literal": "84981204567", "whatsapp_variant": "8481204567"},
+        )
+
+    @override_settings(CONTACT_SEARCH_MIN_VARIANT_LEN=3)
+    def test_lower_variant_floor_allows_shorter_fragments(self):
+        # with floor 3, "9676" -> "676" (3 digits) becomes a valid variant
+        self.assertEqual(
+            get_number_search_terms("9676"),
+            {"literal": "9676", "whatsapp_variant": "676"},
+        )
+
+    @override_settings(CONTACT_SEARCH_MIN_TERM_LEN=5)
+    def test_term_floor_is_configurable(self):
+        # with term floor 5, a 4-digit literal is dropped
+        self.assertEqual(
+            get_number_search_terms("9676"),
+            {"literal": "", "whatsapp_variant": None},
         )


### PR DESCRIPTION
Searching contacts by number on the contacts_elastic endpoint now also matches
WhatsApp URNs stored without the extra Brazilian 9th digit. A new helper
generates the no-9 variant (with a minimum length guard to avoid overly broad
short fragments) and the query uses a bool/should restricted to whatsapp URNs.

Also replaces the in-memory scan() pagination with native from/size and a real
hits.total, fixing total_pages always being 1.