### PR TITLE
fix: check linked pages in instagram view to avoid key error exception

### DIFF
--- a/WENI-CHANGELOG.md
+++ b/WENI-CHANGELOG.md
@@ -1,3 +1,7 @@
+3.80.1
+----------
+* fix: adjust Instagram page access token pagination check and improve token refresh validation message
+
 3.80.0
 ----------
 * feat: improve endpoint to search contacts in elastic excluding the 9th digit

--- a/temba/channels/types/instagram/tests.py
+++ b/temba/channels/types/instagram/tests.py
@@ -155,6 +155,7 @@ class InstagramTypeTest(TembaTest):
             MockResponse(
                 200, json.dumps({"paging": {}, "data": [{"id": "2", "access_token": "", "name": "pagina2"}]})
             ),
+            MockResponse(200, json.dumps({"data": {"is_valid": True}})),
         ]
 
         response = self.client.get(url)
@@ -179,7 +180,13 @@ class InstagramTypeTest(TembaTest):
         post_data["fb_user_id"] = "098765"
         post_data["user_access_token"] = token
 
-        response = self.client.post(url, post_data, follow=True)
+        response = self.client.post(url, post_data)
+
+        self.assertEqual(
+            response.context["form"].errors["__all__"][0],
+            "Unable to refresh the token because this Facebook user doesn't have permission "
+            "on the linked page. Check that you are still an admin on that page and try again.",
+        )
 
     @override_settings(FACEBOOK_APPLICATION_ID="FB_APP_ID", FACEBOOK_APPLICATION_SECRET="FB_APP_SECRET")
     @patch("requests.post")
@@ -371,3 +378,57 @@ class InstagramTypeTest(TembaTest):
             self.client.post(url, post_data, follow=True)
 
         self.assertEqual(str(context.exception), "Failed to get channel page ID")
+
+    @override_settings(FACEBOOK_APPLICATION_ID="FB_APP_ID", FACEBOOK_APPLICATION_SECRET="FB_APP_SECRET")
+    @patch("requests.post")
+    @patch("requests.get")
+    def test_refresh_token_without_page_permission(self, mock_get, mock_post):
+        token = "x" * 200
+        url = reverse("channels.types.instagram.refresh_token", args=(self.channel.uuid,))
+
+        self.login(self.admin)
+
+        mock_get.side_effect = [
+            MockResponse(200, json.dumps({"data": {"is_valid": True}})),
+            MockResponse(200, json.dumps({"access_token": self.long_life_page_token})),
+            MockResponse(200, json.dumps({"data": []})),
+            MockResponse(200, json.dumps({"data": {"is_valid": True}})),
+        ]
+
+        response = self.client.get(url)
+        post_data = response.context["form"].initial
+        post_data["fb_user_id"] = "098765"
+        post_data["user_access_token"] = token
+
+        response = self.client.post(url, post_data)
+
+        self.assertEqual(
+            response.context["form"].errors["__all__"][0],
+            "Unable to refresh the token because this Facebook user doesn't have permission "
+            "on the linked page. Check that you are still an admin on that page and try again.",
+        )
+
+    @override_settings(FACEBOOK_APPLICATION_ID="FB_APP_ID", FACEBOOK_APPLICATION_SECRET="FB_APP_SECRET")
+    @patch("requests.post")
+    @patch("requests.get")
+    def test_claim_without_page_permission(self, mock_get, mock_post):
+        mock_get.side_effect = [
+            MockResponse(200, json.dumps({"access_token": self.long_life_page_token})),
+            MockResponse(200, json.dumps({"data": []})),
+        ]
+
+        url = reverse("channels.types.instagram.claim")
+        self.login(self.admin)
+
+        response = self.client.get(url)
+        post_data = response.context["form"].initial
+        post_data["fb_user_id"] = "098765"
+        post_data["user_access_token"] = self.token
+        post_data["page_id"] = "123456"
+        post_data["page_name"] = "Temba"
+
+        response = self.client.post(url, post_data, follow=True)
+        self.assertEqual(
+            response.context["form"].errors["__all__"][0],
+            "Sorry your Instagram channel could not be connected. Please try again",
+        )

--- a/temba/channels/types/instagram/views.py
+++ b/temba/channels/types/instagram/views.py
@@ -3,6 +3,7 @@ from smartmin.views import SmartFormView, SmartModelActionView
 
 from django import forms
 from django.conf import settings
+from django.core.exceptions import ValidationError
 from django.urls import reverse
 from django.utils.translation import gettext_lazy as _
 
@@ -10,6 +11,28 @@ from temba.orgs.views import ModalMixin, OrgObjPermsMixin
 
 from ...models import Channel
 from ...views import ClaimViewMixin
+
+
+def get_page_access_token(fb_user_id, page_id, long_lived_auth_token):
+    url = f"https://graph.facebook.com/v12.0/{fb_user_id}/accounts"
+    params = {"access_token": long_lived_auth_token}
+
+    while url:
+        response = requests.get(url, params=params)
+
+        if response.status_code != 200:  # pragma: no cover
+            raise Exception("Failed to get a page long lived token")
+
+        response_json = response.json()
+
+        for page in response_json.get("data", []):
+            if page["id"] == str(page_id) and page.get("access_token"):
+                return page["access_token"], page["name"]
+
+        url = response_json.get("paging", {}).get("next", None)
+        params = {}
+
+    raise Exception("Empty page access token!")
 
 
 class ClaimView(ClaimViewMixin, SmartFormView):
@@ -51,35 +74,7 @@ class ClaimView(ClaimViewMixin, SmartFormView):
                 if long_lived_auth_token == "":  # pragma: no cover
                     raise Exception("Empty user access token!")
 
-                url = f"https://graph.facebook.com/v12.0/{fb_user_id}/accounts"
-                params = {"access_token": long_lived_auth_token}
-
-                page_access_token = ""
-
-                while True:
-                    response = requests.get(url, params=params)
-                    response_json = response.json()
-
-                    if response.status_code != 200:  # pragma: no cover
-                        raise Exception("Failed to get a page long lived token")
-
-                    for page in response_json.get("data", []):
-                        if page["id"] == str(page_id):
-                            page_access_token = page["access_token"]
-                            name = page["name"]
-                            break
-
-                    if page_access_token != "":
-                        break
-                    next_ = response_json["paging"].get("next", None)
-
-                    if next_ is not None:
-                        url = next_
-                    else:  # pragma: no cover
-                        break
-
-                if page_access_token == "":  # pragma: no cover
-                    raise Exception("Empty page access token!")
+                page_access_token, name = get_page_access_token(fb_user_id, page_id, long_lived_auth_token)
 
                 url = f"https://graph.facebook.com/v12.0/{page_id}/subscribed_apps"
                 params = {"access_token": page_access_token}
@@ -225,33 +220,15 @@ class RefreshToken(ModalMixin, OrgObjPermsMixin, SmartModelActionView):
         if long_lived_auth_token == "":  # pragma: no cover
             raise Exception("Empty user access token!")
 
-        url = f"https://graph.facebook.com/v12.0/{fb_user_id}/accounts"
-        params = {"access_token": long_lived_auth_token}
-
-        page_access_token = ""
-
-        while True:
-            response = requests.get(url, params=params)
-            response_json = response.json()
-
-            if response.status_code != 200:  # pragma: no cover
-                raise Exception("Failed to get a page long lived token")
-
-            for page in response_json.get("data", []):
-                if page["id"] == str(page_id):
-                    page_access_token = page["access_token"]
-                    name = page["name"]
-                    break
-
-            if page_access_token != "":
-                break
-
-            next_ = response_json["paging"].get("next", None)
-            if next_ is not None:
-                url = next_
-
-            else:  # pragma: no cover
-                break
+        try:
+            page_access_token, name = get_page_access_token(fb_user_id, page_id, long_lived_auth_token)
+        except Exception:
+            raise ValidationError(
+                _(
+                    "Unable to refresh the token because this Facebook user doesn't have permission "
+                    "on the linked page. Check that you are still an admin on that page and try again."
+                )
+            )
 
         url = f"https://graph.facebook.com/v12.0/{page_id}/subscribed_apps"
         params = {"access_token": page_access_token}

--- a/templates/channels/types/instagram/claim.haml
+++ b/templates/channels/types/instagram/claim.haml
@@ -44,7 +44,10 @@
       %input#page-name(type="text" name="page_name")
 
   .mt-4.card#fb-channel-options(style="display:none;")
-    %p(style="font-size:1rem;")
+    #fb-channel-no-pages.mb-4(style="display:none;")
+      %p
+        -trans "No Facebook pages with permission were found for this account. Check that you are still an admin on the page linked to your Instagram business account and try again."
+    %p#fb-channel-select(style="font-size:1rem;")
       -trans "Select the page you want to add as a channel:"
 
 -block extra-less
@@ -124,13 +127,22 @@
             for (var i=0; i < data.length; i++){
               $("#fb-channel-options").append("<div class='fb-page-channel-option lbl mt-3 mr-2 p-2 linked' data-fb-id='" + data[i].id + "' data-fb-name='" + data[i].name + "' data-fb-access-token='" + data[i].access_token +"' >" + data[i].name + " </div>");
             }
+            $("#fb-channel-select").show();
+          } else {
+            $("#fb-channel-no-pages").show();
+            $("#fb-channel-select").hide();
           }
           $("#fb-channel-options").show();
           $("#fb-app-connect").hide();
           $("#throbber").hide();
 
         },
-        failure: function(req){
+        error: function(req){
+          $("#fb-channel-no-pages").show();
+          $("#fb-channel-select").hide();
+          $("#fb-channel-options").show();
+          $("#fb-app-connect").hide();
+          $("#throbber").hide();
         }
       });
     }

--- a/templates/channels/types/instagram/refresh_token.haml
+++ b/templates/channels/types/instagram/refresh_token.haml
@@ -10,6 +10,10 @@
 
 -block form
   .mt-4.card
+    -if form.non_field_errors
+      .alert-error.my-4
+        {{ form.non_field_errors }}
+
     #fb-channel-error.mb-4(style="display:none;")
       %p
         -trans "Error reconnecting Instagram Business Account. Please retry"


### PR DESCRIPTION
Fixes a crash in the Instagram channel integration when the Facebook user has no pages with permission during claim or token refresh.

The code accessed `response_json["paging"]` directly, but the Facebook API returns no paging key when data is empty. This caused a KeyError and a 500 error.

Changes:

- Add safe paging handling via get_page_access_token
- Show a clear error when the user lacks permission on the linked page
- Show a message on claim when no pages are returned
- Display form errors on the refresh token screen