### PR TITLE
feat: implementing generic ticketer type

### DIFF
--- a/temba/settings_common.py
+++ b/temba/settings_common.py
@@ -1228,6 +1228,7 @@ TICKETER_TYPES = [
     "temba.tickets.types.wenichats.WeniChatsType",
     "temba.tickets.types.freshchat.FreshchatType",
     "temba.tickets.types.twilioflex2.TwilioFlex2Type",
+    "temba.tickets.types.generic.GenericType",
 ]
 
 CHANNEL_TYPES = [

--- a/temba/tickets/types/generic/__init__.py
+++ b/temba/tickets/types/generic/__init__.py
@@ -1,0 +1,1 @@
+from .type import GenericType  # noqa

--- a/temba/tickets/types/generic/tests.py
+++ b/temba/tickets/types/generic/tests.py
@@ -1,0 +1,117 @@
+from unittest.mock import patch
+from uuid import uuid4
+
+from django.urls import reverse
+
+from temba.tests import MockResponse
+from temba.tests.base import TembaTest
+from temba.tickets.models import Ticketer
+
+from .type import GenericType
+
+
+class GenericTypeTest(TembaTest):
+    def test_is_available_to(self):
+        self.assertTrue(GenericType().is_available_to(self.admin))
+
+
+class GenericMixin(TembaTest):
+    def setUp(self):
+        super().setUp()
+        self.connect_url = reverse("tickets.types.generic.connect")
+
+
+class GenericViewTest(GenericMixin):
+    def test_connect(self):
+        self.client.force_login(self.admin)
+        data = {
+            "base_url": "https://generic.example.com",
+            "api_token": "api-token-123",
+            "webhook_secret": "webhook-secret-123",
+            "project_uuid": str(uuid4()),
+            "project_name": "org support",
+            "route_open": "/tickets/open",
+            "route_forward": "/tickets/forward",
+            "route_close": "/tickets/close",
+            "route_reopen": "/tickets/reopen",
+            "route_history": "/tickets/history",
+        }
+
+        with patch("requests.get") as mock_get:
+            mock_get.return_value = MockResponse(200, "{}")
+            response = self.client.post(self.connect_url, data=data)
+            self.assertEqual(response.status_code, 302)
+
+            ticketer = Ticketer.objects.order_by("id").last()
+            self.assertEqual(data["project_name"], ticketer.name)
+            self.assertEqual(GenericType.slug, ticketer.ticketer_type)
+            self.assertEqual(data["base_url"], ticketer.config[GenericType.CONFIG_BASE_URL])
+            self.assertEqual(data["api_token"], ticketer.config[GenericType.CONFIG_API_TOKEN])
+            self.assertEqual(data["webhook_secret"], ticketer.config[GenericType.CONFIG_WEBHOOK_SECRET])
+            self.assertEqual(data["project_uuid"], ticketer.config[GenericType.CONFIG_PROJECT_UUID])
+            self.assertEqual(data["project_name"], ticketer.config[GenericType.CONFIG_PROJECT_NAME])
+            self.assertEqual(data["route_open"], ticketer.config[GenericType.CONFIG_ROUTE_OPEN])
+            self.assertEqual(data["route_forward"], ticketer.config[GenericType.CONFIG_ROUTE_FORWARD])
+            self.assertEqual(data["route_close"], ticketer.config[GenericType.CONFIG_ROUTE_CLOSE])
+            self.assertEqual(data["route_reopen"], ticketer.config[GenericType.CONFIG_ROUTE_REOPEN])
+            self.assertEqual(data["route_history"], ticketer.config[GenericType.CONFIG_ROUTE_HISTORY])
+
+            self.assertRedirect(response, reverse("tickets.ticket_list"))
+
+    def test_connect_invalid_base_url(self):
+        self.client.force_login(self.admin)
+        data = {
+            "base_url": "not-a-valid-url",
+            "api_token": "api-token-123",
+            "webhook_secret": "webhook-secret-123",
+            "project_uuid": str(uuid4()),
+            "project_name": "org support",
+            "route_open": "/tickets/open",
+            "route_forward": "/tickets/forward",
+            "route_close": "/tickets/close",
+            "route_reopen": "/tickets/reopen",
+            "route_history": "/tickets/history",
+        }
+
+        response = self.client.post(self.connect_url, data=data)
+        self.assertEqual(response.status_code, 200)
+        self.assertFormError(response, "form", "base_url", "Enter a valid URL.")
+
+    def test_connect_invalid_project_uuid(self):
+        self.client.force_login(self.admin)
+        data = {
+            "base_url": "https://generic.example.com",
+            "api_token": "api-token-123",
+            "webhook_secret": "webhook-secret-123",
+            "project_uuid": "not-a-uuid",
+            "project_name": "org support",
+            "route_open": "/tickets/open",
+            "route_forward": "/tickets/forward",
+            "route_close": "/tickets/close",
+            "route_reopen": "/tickets/reopen",
+            "route_history": "/tickets/history",
+        }
+
+        response = self.client.post(self.connect_url, data=data)
+        self.assertEqual(response.status_code, 200)
+        self.assertFormError(response, "form", "project_uuid", "Enter a valid UUID.")
+
+    def test_connect_missing_required_fields(self):
+        self.client.force_login(self.admin)
+
+        response = self.client.post(self.connect_url, data={})
+        self.assertEqual(response.status_code, 200)
+
+        for field in (
+            "base_url",
+            "api_token",
+            "webhook_secret",
+            "project_uuid",
+            "project_name",
+            "route_open",
+            "route_forward",
+            "route_close",
+            "route_reopen",
+            "route_history",
+        ):
+            self.assertFormError(response, "form", field, "This field is required.")

--- a/temba/tickets/types/generic/type.py
+++ b/temba/tickets/types/generic/type.py
@@ -1,0 +1,35 @@
+from django.utils.translation import ugettext_lazy as _
+
+from temba.tickets.models import TicketerType
+from temba.tickets.types.generic.views import ConnectView
+
+
+class GenericType(TicketerType):
+    """
+    Generic ticketer type.
+    """
+
+    name = "Generic"
+    slug = "generic"
+    icon = "icon-channel-external"
+
+    CONFIG_BASE_URL = "base_url"
+    CONFIG_API_TOKEN = "api_token"
+    CONFIG_WEBHOOK_SECRET = "webhook_secret"
+
+    # Optional metadata enrichment for partner-side context
+    CONFIG_PROJECT_UUID = "project_uuid"
+    CONFIG_PROJECT_NAME = "project_name"
+
+    # Optional per-endpoint route overrides. When empty, DefaultRoutes is used.
+    CONFIG_ROUTE_OPEN = "route_open"
+    CONFIG_ROUTE_FORWARD = "route_forward"
+    CONFIG_ROUTE_CLOSE = "route_close"
+    CONFIG_ROUTE_REOPEN = "route_reopen"
+    CONFIG_ROUTE_HISTORY = "route_history"
+
+    connect_view = ConnectView
+    connect_blurb = _("%(link)s generic ticketer.") % {"link": '<a href="https://www.generic.com/">Generic</a>'}
+
+    def is_available_to(self, user):
+        return True

--- a/temba/tickets/types/generic/views.py
+++ b/temba/tickets/types/generic/views.py
@@ -1,0 +1,77 @@
+from django import forms
+from django.utils.translation import ugettext_lazy as _
+
+from temba.tickets.models import Ticketer
+from temba.tickets.views import BaseConnectView
+from temba.utils.uuid import uuid4
+
+
+class ConnectView(BaseConnectView):
+    class Form(BaseConnectView.Form):
+        base_url = forms.URLField(label=_("Base URL"), help_text=_("The base URL of the generic ticketer"))
+        api_token = forms.CharField(label=_("API Token"), help_text=_("The API token of the generic ticketer"))
+        webhook_secret = forms.CharField(
+            label=_("Webhook Secret"), help_text=_("The webhook secret of the generic ticketer")
+        )
+        project_uuid = forms.UUIDField(
+            label=_("Project UUID"), help_text=_("The project UUID of the generic ticketer")
+        )
+        project_name = forms.CharField(
+            label=_("Project Name"), help_text=_("The project name of the generic ticketer")
+        )
+        route_open = forms.CharField(label=_("Route Open"), help_text=_("The route open of the generic ticketer"))
+        route_forward = forms.CharField(
+            label=_("Route Forward"), help_text=_("The route forward of the generic ticketer")
+        )
+        route_close = forms.CharField(label=_("Route Close"), help_text=_("The route close of the generic ticketer"))
+        route_reopen = forms.CharField(
+            label=_("Route Reopen"), help_text=_("The route reopen of the generic ticketer")
+        )
+        route_history = forms.CharField(
+            label=_("Route History"), help_text=_("The route history of the generic ticketer")
+        )
+
+        def clean(self):
+            return self.cleaned_data
+
+    def form_valid(self, form):
+        from .type import GenericType
+
+        base_url = form.cleaned_data["base_url"]
+        api_token = form.cleaned_data["api_token"]
+        webhook_secret = form.cleaned_data["webhook_secret"]
+        project_uuid = form.cleaned_data["project_uuid"]
+        project_name = form.cleaned_data["project_name"]
+        route_open = form.cleaned_data["route_open"]
+        route_forward = form.cleaned_data["route_forward"]
+        route_close = form.cleaned_data["route_close"]
+        route_reopen = form.cleaned_data["route_reopen"]
+        route_history = form.cleaned_data["route_history"]
+
+        config = {
+            GenericType.CONFIG_BASE_URL: base_url,
+            GenericType.CONFIG_API_TOKEN: api_token,
+            GenericType.CONFIG_WEBHOOK_SECRET: webhook_secret,
+            GenericType.CONFIG_PROJECT_UUID: project_uuid,
+            GenericType.CONFIG_PROJECT_NAME: project_name,
+            GenericType.CONFIG_ROUTE_OPEN: route_open,
+            GenericType.CONFIG_ROUTE_FORWARD: route_forward,
+            GenericType.CONFIG_ROUTE_CLOSE: route_close,
+            GenericType.CONFIG_ROUTE_REOPEN: route_reopen,
+            GenericType.CONFIG_ROUTE_HISTORY: route_history,
+        }
+
+        self.object = Ticketer(
+            uuid=uuid4(),
+            org=self.org,
+            ticketer_type=GenericType.slug,
+            config=config,
+            name=project_name,
+            created_by=self.request.user,
+            modified_by=self.request.user,
+        )
+        self.object.save()
+        return super().form_valid(form)
+
+    form_class = Form
+    template_name = "tickets/types/generic/connect.haml"

--- a/temba/tickets/types/generic/views.py
+++ b/temba/tickets/types/generic/views.py
@@ -52,7 +52,7 @@ class ConnectView(BaseConnectView):
             GenericType.CONFIG_BASE_URL: base_url,
             GenericType.CONFIG_API_TOKEN: api_token,
             GenericType.CONFIG_WEBHOOK_SECRET: webhook_secret,
-            GenericType.CONFIG_PROJECT_UUID: project_uuid,
+            GenericType.CONFIG_PROJECT_UUID: str(project_uuid),
             GenericType.CONFIG_PROJECT_NAME: project_name,
             GenericType.CONFIG_ROUTE_OPEN: route_open,
             GenericType.CONFIG_ROUTE_FORWARD: route_forward,

--- a/templates/tickets/types/generic/connect.haml
+++ b/templates/tickets/types/generic/connect.haml
@@ -1,0 +1,2 @@
+-extends "tickets/ticketer_connect_form.html"
+-load i18n compress temba


### PR DESCRIPTION
### Summary
Adds a new Generic ticketer type so organizations can connect to external ticketing systems via configurable HTTP endpoints.

### Changes

- Introduces GenericType with connect flow for base URL, API token, webhook secret, project metadata, and per-action route overrides (open, forward, close, reopen, history)

- Registers the type in TICKETER_TYPES

- Adds connect view, template, and tests covering successful setup and form validation
