### PR TITLE
fix: fall back for export exceeding s3 select limit

### DIFF
--- a/WENI-CHANGELOG.md
+++ b/WENI-CHANGELOG.md
@@ -1,3 +1,8 @@
+3.81.1
+----------
+* fix: fall back to local filtering when exporting flow results from archives with records that exceed the S3 Select limit (OverMaxRecordSize)
+* feat: add queue porpuse in get departments
+
 3.81.0
 ----------
 * feat: add generic ticketer type

--- a/temba/archives/models.py
+++ b/temba/archives/models.py
@@ -7,6 +7,7 @@ from datetime import date, datetime
 from gettext import gettext as _
 from urllib.parse import urlparse
 
+from botocore.exceptions import ClientError
 from dateutil.relativedelta import relativedelta
 
 from django.conf import settings
@@ -184,9 +185,24 @@ class Archive(models.Model):
         """
 
         s3_client = s3.client()
+        bucket, key = self.get_storage_location()
 
-        if where:
-            bucket, key = self.get_storage_location()
+        if not where:
+            s3_obj = s3_client.get_object(Bucket=bucket, Key=key)
+            return jsonlgz_iterate(s3_obj["Body"])
+
+        return self._iter_filtered_records(s3_client, bucket, key, where)
+
+    def _iter_filtered_records(self, s3_client, bucket: str, key: str, where: dict):
+        """
+        Streams records matching the given criteria using S3 Select, falling back to local filtering if a record is
+        too big for S3 Select
+        """
+        # track how many records S3 Select streamed so that, if it fails partway through, we can resume from the same
+        # point when falling back to local filtering (records are streamed in file order using the same criteria)
+        num_yielded = 0
+
+        try:
             response = s3_client.select_object_content(
                 Bucket=bucket,
                 Key=key,
@@ -196,16 +212,34 @@ class Archive(models.Model):
                 OutputSerialization={"JSON": {"RecordDelimiter": "\n"}},
             )
 
-            def generator():
-                for record in EventStreamReader(response["Payload"]):
-                    yield record
+            for record in EventStreamReader(response["Payload"]):
+                num_yielded += 1
+                yield record
+        except ClientError as e:
+            # S3 Select can't read archives that contain a record longer than 1 MB (OverMaxRecordSize), so fall back
+            # to downloading the whole archive and filtering it locally, which has no such limit
+            if e.response.get("Error", {}).get("Code") != "OverMaxRecordSize":
+                raise
 
-            return generator()
+            yield from self._iter_local_records(s3_client, bucket, key, where, skip=num_yielded)
 
-        else:
-            bucket, key = self.get_storage_location()
-            s3_obj = s3_client.get_object(Bucket=bucket, Key=key)
-            return jsonlgz_iterate(s3_obj["Body"])
+    def _iter_local_records(self, s3_client, bucket: str, key: str, where: dict, *, skip: int = 0):
+        """
+        Downloads the whole archive and filters records locally, skipping the first `skip` matching records (those
+        already streamed by S3 Select before it failed)
+        """
+        s3_obj = s3_client.get_object(Bucket=bucket, Key=key)
+        num_skipped = 0
+
+        for record in jsonlgz_iterate(s3_obj["Body"]):
+            if not s3.matches_where(record, where=where):
+                continue
+
+            if num_skipped < skip:
+                num_skipped += 1
+                continue
+
+            yield record
 
     def rewrite(self, transform, delete_old=False):
         s3_client = s3.client()

--- a/temba/archives/tests.py
+++ b/temba/archives/tests.py
@@ -6,12 +6,13 @@ from datetime import date, datetime
 from unittest.mock import call, patch
 
 import pytz
+from botocore.exceptions import ClientError
 
 from django.urls import reverse
 from django.utils import timezone
 
 from temba.tests import CRUDLTestMixin, TembaTest
-from temba.tests.s3 import MockS3Client
+from temba.tests.s3 import MockEventStream, MockS3Client
 
 from .models import Archive, jsonlgz_rewrite
 
@@ -67,6 +68,56 @@ class ArchiveTest(TembaTest):
                 OutputSerialization={"JSON": {"RecordDelimiter": "\n"}},
             ),
         )
+
+    @patch("temba.utils.s3.client")
+    def test_iter_records_over_max_record_size(self, mock_s3_client):
+        # simulate an archive where the second record is too big for S3 Select
+        mock_s3 = MockS3Client(max_chars_per_record=60)
+        mock_s3_client.return_value = mock_s3
+
+        records = [
+            {"id": 1, "responded": True},
+            {"id": 2, "responded": True, "padding": "x" * 100},  # too long for S3 Select
+            {"id": 3, "responded": True},
+            {"id": 4, "responded": False},
+        ]
+        archive = self.create_archive(Archive.TYPE_FLOWRUN, "D", timezone.now().date(), records, s3=mock_s3)
+
+        # S3 Select streams the first record, fails on the oversized one, then we fall back to filtering locally,
+        # returning the remaining matching records (including the oversized one) without duplicates
+        records_iter = archive.iter_records(where={"responded": True})
+
+        self.assertEqual(
+            [
+                {"id": 1, "responded": True},
+                {"id": 2, "responded": True, "padding": "x" * 100},
+                {"id": 3, "responded": True},
+            ],
+            list(records_iter),
+        )
+
+        # we used S3 Select first and then fell back to downloading the whole object
+        self.assertEqual(1, len(mock_s3.calls["select_object_content"]))
+        self.assertEqual(1, len(mock_s3.calls["get_object"]))
+
+    @patch("temba.utils.s3.client")
+    def test_iter_records_reraises_other_s3_errors(self, mock_s3_client):
+        mock_s3 = MockS3Client()
+        mock_s3_client.return_value = mock_s3
+
+        archive = self.create_archive(
+            Archive.TYPE_FLOWRUN, "D", timezone.now().date(), [{"id": 1, "responded": True}], s3=mock_s3
+        )
+
+        # S3 Select errors other than OverMaxRecordSize should propagate rather than trigger the local fallback
+        error = ClientError({"Error": {"Code": "InternalError", "Message": "boom"}}, "SelectObjectContent")
+        with patch.object(
+            mock_s3, "select_object_content", return_value={"Payload": MockEventStream([], error=error)}
+        ):
+            with self.assertRaises(ClientError):
+                list(archive.iter_records(where={"responded": True}))
+
+        self.assertEqual(0, len(mock_s3.calls["get_object"]))
 
     @patch("temba.utils.s3.client")
     def test_iter_all_records(self, mock_s3_client):

--- a/temba/tests/s3.py
+++ b/temba/tests/s3.py
@@ -6,13 +6,14 @@ from unittest.mock import call
 
 import iso8601
 import regex
+from botocore.exceptions import ClientError
 
 from temba.archives.models import FileAndHash, jsonlgz_iterate
 from temba.utils import chunk_list, json
 
 
 class MockEventStream:
-    def __init__(self, records: list[dict], max_payload_size: int = 256):
+    def __init__(self, records: list[dict], max_payload_size: int = 256, error: Exception = None):
         # serialize records as a JSONL payload
         buffer = io.BytesIO()
         for record in records:
@@ -23,14 +24,22 @@ class MockEventStream:
         payload_chunks = chunk_list(payload, size=max_payload_size)
 
         self.events = [{"Records": {"Payload": chunk}} for chunk in payload_chunks]
-        self.events.append(
-            {"Stats": {"Details": {"BytesScanned": 123, "BytesProcessed": 234, "BytesReturned": len(payload)}}},
-        )
-        self.events.append({"End": {}})
+
+        # if simulating a mid-stream failure, don't emit the closing events
+        self.error = error
+        if not error:
+            self.events.append(
+                {"Stats": {"Details": {"BytesScanned": 123, "BytesProcessed": 234, "BytesReturned": len(payload)}}},
+            )
+            self.events.append({"End": {}})
 
     def __iter__(self):
         for event in self.events:
             yield event
+
+        # S3 Select raises while the payload is being consumed, so do the same after emitting the events so far
+        if self.error:
+            raise self.error
 
 
 class MockS3Client:
@@ -38,9 +47,13 @@ class MockS3Client:
     A mock of the boto S3 client
     """
 
-    def __init__(self):
+    def __init__(self, max_chars_per_record: int = None):
         self.objects = {}
         self.calls = defaultdict(list)
+
+        # if set, select_object_content simulates the S3 OverMaxRecordSize error when it reaches a record whose
+        # serialized length exceeds this threshold (matching real S3 Select behavior)
+        self.max_chars_per_record = max_chars_per_record
 
     def put_object(self, Bucket: str, Key: str, Body, **kwargs):
         self.calls["put_object"].append(call(Bucket=Bucket, Key=Key, Body=Body, **kwargs))
@@ -75,12 +88,26 @@ class MockS3Client:
         stream = self.objects[(Bucket, Key)]
         stream.seek(0)
         records = []
+        error = None
 
         for record in jsonlgz_iterate(stream):
+            # S3 Select fails when it reaches a record that's too long, regardless of whether it matches
+            if self.max_chars_per_record and len(json.dumps(record)) > self.max_chars_per_record:
+                error = ClientError(
+                    {
+                        "Error": {
+                            "Code": "OverMaxRecordSize",
+                            "Message": "The character number in one record is more than our max threshold",
+                        }
+                    },
+                    "SelectObjectContent",
+                )
+                break
+
             if select_matches(Expression, record):
                 records.append(record)
 
-        return {"Payload": MockEventStream(records)}
+        return {"Payload": MockEventStream(records, error=error)}
 
 
 def jsonlgz_encode(records: list) -> tuple:

--- a/temba/utils/s3/select.py
+++ b/temba/utils/s3/select.py
@@ -1,5 +1,7 @@
 from datetime import datetime
 
+import iso8601
+
 LOOKUPS = {"gt": ">", "gte": ">=", "lte": "<=", "lt": "<", "in": "IN"}
 
 
@@ -54,3 +56,50 @@ def _compile_value(val) -> str:
     if isinstance(val, (list, tuple)):
         return f"({', '.join([_compile_value(v) for v in val])})"
     return str(val)
+
+
+def matches_where(record: dict, *, where: dict = None) -> bool:
+    """
+    Client-side equivalent of compile_select, used as a fallback to filter records locally when S3 Select can't be
+    used (e.g. an archive contains a record which exceeds the OverMaxRecordSize limit)
+    """
+    if not where:
+        return True
+
+    for field, val in where.items():
+        if field == "__raw__":
+            raise ValueError("can't evaluate a raw S3 select expression locally")
+        if not _condition_matches(record, field, val):
+            return False
+
+    return True
+
+
+def _condition_matches(record: dict, field: str, val) -> bool:
+    op = "="
+    field_parts = field.split("__")
+    if field_parts[-1] in LOOKUPS:
+        op = LOOKUPS[field_parts[-1]]
+        field_parts = field_parts[:-1]
+
+    actual = record
+    for part in field_parts:
+        if not isinstance(actual, dict) or part not in actual:
+            actual = None
+            break
+        actual = actual[part]
+
+    # a missing field never matches any condition (consistent with S3 Select's handling of MISSING values)
+    if actual is None:
+        return False
+
+    # record datetimes are stored as ISO strings, so parse before comparing
+    if isinstance(val, datetime) and isinstance(actual, str):
+        actual = iso8601.parse_date(actual)
+
+    if op == "=":
+        return actual == val
+    if op == "IN":
+        return actual in val
+
+    return {">": actual > val, ">=": actual >= val, "<": actual < val, "<=": actual <= val}[op]

--- a/temba/utils/s3/tests.py
+++ b/temba/utils/s3/tests.py
@@ -6,7 +6,7 @@ import pytz
 
 from temba.tests import TembaTest
 from temba.tests.s3 import MockEventStream, MockS3Client
-from temba.utils.s3 import EventStreamReader, compile_select, get_body, split_url
+from temba.utils.s3 import EventStreamReader, compile_select, get_body, matches_where, split_url
 
 
 class S3Test(TembaTest):
@@ -85,3 +85,49 @@ class SelectTest(TembaTest):
             "SELECT s.* FROM s3object s WHERE '1ccf09f6-3fe8-4c0d-a073-981632be5a30' IN s.labels[*].uuid[*]",
             compile_select(where={"__raw__": "'1ccf09f6-3fe8-4c0d-a073-981632be5a30' IN s.labels[*].uuid[*]"}),
         )
+
+    def test_matches_where(self):
+        record = {
+            "id": 123,
+            "responded": True,
+            "flow": {"uuid": "1234", "name": "Test"},
+            "created_on": "2021-09-28T18:27:30.123456+00:00",
+        }
+
+        # no where always matches
+        self.assertTrue(matches_where(record))
+        self.assertTrue(matches_where(record, where={}))
+
+        # exact match on top-level and nested fields
+        self.assertTrue(matches_where(record, where={"id": 123}))
+        self.assertFalse(matches_where(record, where={"id": 456}))
+        self.assertTrue(matches_where(record, where={"responded": True}))
+        self.assertTrue(matches_where(record, where={"flow__uuid": "1234"}))
+        self.assertFalse(matches_where(record, where={"flow__uuid": "9999"}))
+
+        # comparison lookups
+        self.assertTrue(matches_where(record, where={"id__gt": 100}))
+        self.assertFalse(matches_where(record, where={"id__gt": 200}))
+        self.assertTrue(matches_where(record, where={"id__gte": 123, "id__lte": 123}))
+
+        # IN lookup
+        self.assertTrue(matches_where(record, where={"flow__uuid__in": ("1234", "2345")}))
+        self.assertFalse(matches_where(record, where={"flow__uuid__in": ("2345",)}))
+
+        # datetime values compared against ISO string fields
+        self.assertTrue(matches_where(record, where={"created_on__gt": datetime(2021, 9, 28, 0, 0, 0, 0, pytz.UTC)}))
+        self.assertFalse(matches_where(record, where={"created_on__gt": datetime(2021, 9, 29, 0, 0, 0, 0, pytz.UTC)}))
+
+        # all conditions must match
+        self.assertTrue(matches_where(record, where={"flow__uuid": "1234", "responded": True}))
+        self.assertFalse(matches_where(record, where={"flow__uuid": "1234", "responded": False}))
+
+        # a missing field never matches any lookup, consistently across operators
+        self.assertFalse(matches_where(record, where={"missing__gt": 1}))
+        self.assertFalse(matches_where(record, where={"missing": None}))
+        self.assertFalse(matches_where(record, where={"missing__in": (1, 2)}))
+        self.assertFalse(matches_where(record, where={"missing__in": (None, 1)}))
+
+        # raw expressions can't be evaluated locally
+        with self.assertRaises(ValueError):
+            matches_where(record, where={"__raw__": "s.id < 3"})


### PR DESCRIPTION
Fixes flow results export failing when an S3 archive contains a record larger than the S3 Select limit of 1 MB, which raised `ClientError: OverMaxRecordSize` and brought down the entire export.

When S3 Select fails with `OverMaxRecordSize`, `Archive.iter_records` now falls back to downloading the full archive and filtering records locally (which has no such limit), resuming from where S3 Select stopped — without duplicating records and without altering any archived data. Other S3 errors are still propagated as before.