### PR TITLE
feat: default bare phone URNs to whatsapp on API and import

### DIFF
--- a/WENI-CHANGELOG.md
+++ b/WENI-CHANGELOG.md
@@ -1,3 +1,7 @@
+3.83.0
+----------
+* feat: default bare phone URNs to whatsapp on API, import and contact create form
+
 3.82.0
 ----------
 * feat: add internal endpoint for ticketer creation

--- a/temba/api/v2/fields.py
+++ b/temba/api/v2/fields.py
@@ -134,8 +134,11 @@ class URNField(serializers.CharField):
             return str(obj)
 
     def to_internal_value(self, data):
+        if not isinstance(data, str):
+            raise serializers.ValidationError("Not a valid string.")
+
         country_code = self.context["org"].default_country_code
-        return validate_urn(str(data), country_code=country_code)
+        return validate_urn(data, country_code=country_code)
 
 
 class URNListField(LimitedListField):

--- a/temba/api/v2/fields.py
+++ b/temba/api/v2/fields.py
@@ -39,6 +39,7 @@ def validate_translations(value, base_language, max_length):
 
 def validate_urn(value, strict=True, country_code=None):
     try:
+        value = URN.ensure_scheme(value, country_code=country_code)
         normalized = URN.normalize(value, country_code=country_code)
 
         if strict and not URN.validate(normalized, country_code=country_code):
@@ -46,13 +47,18 @@ def validate_urn(value, strict=True, country_code=None):
     except ValueError:
         raise serializers.ValidationError("Invalid URN: %s. Ensure phone numbers contain country codes." % value)
 
-    # enforce strict 8-15 digit length on tel: URNs (does not affect other schemes).
+    # enforce strict 8-15 digit length on phone-based URNs (does not affect other schemes).
     # URN.normalize already guarantees the result is parseable, so URN.to_parts is safe here.
     if strict:
         scheme, path, _, _ = URN.to_parts(normalized)
         if scheme == URN.TEL_SCHEME:
             try:
                 validate_contact_phone(path)
+            except DjangoValidationError as e:
+                raise serializers.ValidationError(str(e.messages[0]))
+        elif scheme == URN.WHATSAPP_SCHEME and path.isdigit():
+            try:
+                validate_contact_phone(f"+{path}")
             except DjangoValidationError as e:
                 raise serializers.ValidationError(str(e.messages[0]))
 

--- a/temba/api/v2/tests.py
+++ b/temba/api/v2/tests.py
@@ -329,6 +329,8 @@ class APITest(TembaTest):
                 "tel:+1-800-123-4567": "tel:+18001234567",
                 "tel:0788 123 123": "tel:+250788123123",  # using org country
                 "tel:(078) 812-3123": "tel:+250788123123",
+                "+250788123123": "whatsapp:250788123123",  # bare phone defaults to whatsapp
+                "0788 123 123": "whatsapp:250788123123",  # bare phone defaults to whatsapp
                 "12345": serializers.ValidationError,  # un-parseable
                 "tel:800-123-4567": serializers.ValidationError,  # no country code
                 18_001_234_567: serializers.ValidationError,  # non-string
@@ -2869,6 +2871,24 @@ class APITest(TembaTest):
         self.assertEqual(set(jean.urns.values_list("identity", flat=True)), {"tel:+250783333333", "twitter:jean"})
         self.assertEqual(set(jean.user_groups.all()), {group})
         self.assertEqual(jean.get_field_value(nickname), "Jado")
+
+        # bare phone numbers default to whatsapp URNs
+        response = self.postJSON(url, None, {"name": "WhatsUser", "urns": ["+250788999999"]})
+        self.assertEqual(response.status_code, 201)
+        self.assertEqual(response.json()["urns"], ["whatsapp:250788999999"])
+
+        whats_user = Contact.objects.get(name="WhatsUser")
+        self.assertEqual(set(whats_user.urns.values_list("identity", flat=True)), {"whatsapp:250788999999"})
+
+        # explicit tel scheme is preserved
+        response = self.postJSON(url, None, {"name": "TelUser", "urns": ["tel:+250788888888"]})
+        self.assertEqual(response.status_code, 201)
+        self.assertEqual(response.json()["urns"], ["tel:+250788888888"])
+
+        # explicit whatsapp scheme is preserved
+        response = self.postJSON(url, None, {"name": "ExplicitWhats", "urns": ["whatsapp:250788777777"]})
+        self.assertEqual(response.status_code, 201)
+        self.assertEqual(response.json()["urns"], ["whatsapp:250788777777"])
 
         # try to create with group from other org
         response = self.postJSON(url, None, {"name": "Jim", "groups": [other_org_group.uuid]})

--- a/temba/api/v2/tests.py
+++ b/temba/api/v2/tests.py
@@ -2891,6 +2891,12 @@ class APITest(TembaTest):
         self.assertEqual(response.status_code, 201)
         self.assertEqual(response.json()["urns"], ["whatsapp:5511987654321"])
 
+        # restore default org country for subsequent tests in this method
+        self.org.timezone = "Africa/Kigali"
+        self.org.save(update_fields=("timezone",))
+        if "default_country" in self.org.__dict__:
+            del self.org.__dict__["default_country"]
+
         # explicit tel scheme is preserved
         response = self.postJSON(url, None, {"name": "TelUser", "urns": ["tel:+250788888888"]})
         self.assertEqual(response.status_code, 201)

--- a/temba/api/v2/tests.py
+++ b/temba/api/v2/tests.py
@@ -2881,6 +2881,16 @@ class APITest(TembaTest):
         whats_user = Contact.objects.get(name="WhatsUser")
         self.assertEqual(set(whats_user.urns.values_list("identity", flat=True)), {"whatsapp:250788999999"})
 
+        # bare brazilian numbers are normalized with country code 55
+        self.org.timezone = "America/Sao_Paulo"
+        self.org.save(update_fields=("timezone",))
+        if "default_country" in self.org.__dict__:
+            del self.org.__dict__["default_country"]
+
+        response = self.postJSON(url, None, {"name": "BR User", "urns": ["11987654321"]})
+        self.assertEqual(response.status_code, 201)
+        self.assertEqual(response.json()["urns"], ["whatsapp:5511987654321"])
+
         # explicit tel scheme is preserved
         response = self.postJSON(url, None, {"name": "TelUser", "urns": ["tel:+250788888888"]})
         self.assertEqual(response.status_code, 201)

--- a/temba/api/v2/tests.py
+++ b/temba/api/v2/tests.py
@@ -331,6 +331,7 @@ class APITest(TembaTest):
                 "tel:(078) 812-3123": "tel:+250788123123",
                 "+250788123123": "whatsapp:250788123123",  # bare phone defaults to whatsapp
                 "0788 123 123": "whatsapp:250788123123",  # bare phone defaults to whatsapp
+                "whatsapp:6831234": serializers.ValidationError,  # too few digits
                 "12345": serializers.ValidationError,  # un-parseable
                 "tel:800-123-4567": serializers.ValidationError,  # no country code
                 18_001_234_567: serializers.ValidationError,  # non-string

--- a/temba/api/v2/views_base.py
+++ b/temba/api/v2/views_base.py
@@ -235,6 +235,7 @@ class BaseAPIView(NonAtomicMixin, generics.GenericAPIView):
             raise InvalidQueryError("URN lookups not allowed for anonymous organizations")
 
         try:
+            value = URN.ensure_scheme(value, country_code=org.default_country_code)
             return URN.identity(URN.normalize(value, country_code=org.default_country_code))
         except ValueError:
             raise InvalidQueryError("Invalid URN: %s" % value)

--- a/temba/contacts/models.py
+++ b/temba/contacts/models.py
@@ -104,6 +104,24 @@ class URN:
 
     VALID_SCHEMES = {s[0] for s in SCHEME_CHOICES}
 
+    DEFAULT_PHONE_SCHEME = WHATSAPP_SCHEME
+
+    PHONE_COLUMN_HEADERS = frozenset(
+        {
+            "phone",
+            "mobile",
+            "telephone",
+            "cell",
+            "cellphone",
+            "cell phone",
+            "phone number",
+            "mobile number",
+            "contact phone",
+            "contact mobile",
+            "number",
+        }
+    )
+
     FACEBOOK_PATH_REF_PREFIX = "ref:"
 
     def __init__(self):  # pragma: no cover
@@ -269,6 +287,13 @@ class URN:
         elif scheme == cls.EMAIL_SCHEME:
             norm_path = norm_path.lower()
 
+        elif scheme == cls.WHATSAPP_SCHEME:
+            # phone-based whatsapp URNs are stored as E.164 without the + prefix
+            if norm_path and norm_path[0] in "+0123456789":
+                norm_path = cls.normalize_number(norm_path, country_code)
+                if norm_path.startswith("+"):
+                    norm_path = norm_path[1:]
+
         return cls.from_parts(scheme, norm_path, query, display)
 
     @classmethod
@@ -314,6 +339,53 @@ class URN:
     @classmethod
     def from_tel(cls, path):
         return cls.from_parts(cls.TEL_SCHEME, path)
+
+    @classmethod
+    def from_whatsapp(cls, path):
+        return cls.from_parts(cls.WHATSAPP_SCHEME, path)
+
+    @classmethod
+    def looks_like_phone(cls, value, country_code=None):
+        """
+        Returns whether the given value appears to be a phone number without an explicit URN scheme.
+        """
+        if not isinstance(value, str):
+            return False
+
+        value = value.strip()
+        if not value or ":" in value:
+            return False
+
+        if not any(c.isdigit() for c in value):
+            return False
+
+        # non-phone identifiers such as BSUIDs require an explicit scheme
+        if regex.match(r"^[A-Z]{2}\.", value, regex.V0):
+            return False
+
+        try:
+            parse_number(cls.normalize_number(value, country_code or ""), country_code)
+            return True
+        except ValueError:
+            return False
+
+    @classmethod
+    def ensure_scheme(cls, value, country_code=None, default_phone_scheme=None):
+        """
+        Returns a URN string, inferring the default phone scheme when no scheme is provided.
+        """
+        if default_phone_scheme is None:
+            default_phone_scheme = cls.DEFAULT_PHONE_SCHEME
+
+        value = str(value).strip()
+
+        if ":" in value:
+            return value
+
+        if cls.looks_like_phone(value, country_code):
+            return cls.from_parts(default_phone_scheme, value)
+
+        raise ValueError("URN strings must contain scheme and path components")
 
     @classmethod
     def from_twitterid(cls, id, screen_name=None):
@@ -2275,7 +2347,7 @@ class ContactImport(SmartModel):
             elif mapping["type"] == "scheme" and value:
                 urn = URN.from_parts(mapping["scheme"], value)
                 try:
-                    urn = URN.normalize(urn)
+                    urn = URN.normalize(urn, country_code=org.default_country_code)
                 except ValueError:
                     pass
                 urns.append(urn)
@@ -2305,6 +2377,8 @@ class ContactImport(SmartModel):
 
                 if attribute in ("uuid", "name", "language"):
                     mapping = {"type": "attribute", "name": attribute}
+                elif attribute in cls.PHONE_COLUMN_HEADERS:
+                    mapping = {"type": "scheme", "scheme": cls.DEFAULT_PHONE_SCHEME}
             elif header_prefix == "urn" and header_name:
                 mapping = {"type": "scheme", "scheme": header_name.lower()}
             elif header_prefix == "field" and header_name:

--- a/temba/contacts/models.py
+++ b/temba/contacts/models.py
@@ -347,8 +347,14 @@ class URN:
         return candidates or [normalized]
 
     @classmethod
-    def _formatted_number_matches_country(cls, formatted: str, number: str, country_code: str) -> bool:
+    def _formatted_number_matches_country(
+        cls, formatted: str, parse_as: str, number: str, normalized: str, country_code: str
+    ) -> bool:
         if not country_code or number.startswith("+"):
+            return True
+
+        # accept valid international numbers even when they don't match the org country
+        if parse_as == "+" + normalized:
             return True
 
         try:
@@ -372,7 +378,7 @@ class URN:
             except ValueError:
                 continue
 
-            if cls._formatted_number_matches_country(formatted, number, country_code):
+            if cls._formatted_number_matches_country(formatted, parse_as, number, normalized, country_code):
                 return formatted
 
         return normalized

--- a/temba/contacts/models.py
+++ b/temba/contacts/models.py
@@ -329,9 +329,17 @@ class URN:
             return ["+" + normalized]
 
         candidates = []
+        has_international = len(normalized) >= 11 and not normalized.startswith("0")
+
+        if country_code and has_international:
+            calling_code = str(phonenumbers.country_code_for_region(country_code.upper()))
+            if calling_code and normalized.startswith(calling_code):
+                candidates.append("+" + normalized)
+
         if country_code:
             candidates.append(normalized)
-        if len(normalized) >= 11 and not normalized.startswith("0"):
+
+        if has_international:
             international = "+" + normalized
             if international not in candidates:
                 candidates.append(international)
@@ -339,21 +347,16 @@ class URN:
         return candidates or [normalized]
 
     @classmethod
-    def _formatted_number_matches_country(
-        cls, formatted: str, parse_as: str, number: str, normalized: str, country_code: str
-    ) -> bool:
+    def _formatted_number_matches_country(cls, formatted: str, number: str, country_code: str) -> bool:
         if not country_code or number.startswith("+"):
             return True
 
         try:
             parsed = phonenumbers.parse(formatted, None)
             region = phonenumbers.region_code_for_number(parsed)
-            if region and region != country_code.upper() and parse_as != "+" + normalized:
-                return False
+            return region == country_code.upper()
         except phonenumbers.NumberParseException:
             return False
-
-        return True
 
     @classmethod
     def normalize_number(cls, number: str, country_code: str):
@@ -369,7 +372,7 @@ class URN:
             except ValueError:
                 continue
 
-            if cls._formatted_number_matches_country(formatted, parse_as, number, normalized, country_code):
+            if cls._formatted_number_matches_country(formatted, number, country_code):
                 return formatted
 
         return normalized

--- a/temba/contacts/models.py
+++ b/temba/contacts/models.py
@@ -2377,8 +2377,8 @@ class ContactImport(SmartModel):
 
                 if attribute in ("uuid", "name", "language"):
                     mapping = {"type": "attribute", "name": attribute}
-                elif attribute in cls.PHONE_COLUMN_HEADERS:
-                    mapping = {"type": "scheme", "scheme": cls.DEFAULT_PHONE_SCHEME}
+                elif attribute in URN.PHONE_COLUMN_HEADERS:
+                    mapping = {"type": "scheme", "scheme": URN.DEFAULT_PHONE_SCHEME}
             elif header_prefix == "urn" and header_name:
                 mapping = {"type": "scheme", "scheme": header_name.lower()}
             elif header_prefix == "field" and header_name:

--- a/temba/contacts/models.py
+++ b/temba/contacts/models.py
@@ -315,54 +315,62 @@ class URN:
         return cls.from_parts(scheme, norm_path, query, display)
 
     @classmethod
+    def _sanitize_number_digits(cls, number: str) -> str:
+        normalized = number.strip().lower()
+
+        if normalized.endswith("e+11") or normalized.endswith("e+12"):
+            normalized = normalized[0:-4].replace(".", "")
+
+        return regex.sub(r"[^0-9a-z]", "", normalized, regex.V0)
+
+    @classmethod
+    def _number_parse_candidates(cls, number: str, normalized: str, country_code: str) -> list[str]:
+        if number.startswith("+"):
+            return ["+" + normalized]
+
+        candidates = []
+        if country_code:
+            candidates.append(normalized)
+        if len(normalized) >= 11 and not normalized.startswith("0"):
+            international = "+" + normalized
+            if international not in candidates:
+                candidates.append(international)
+
+        return candidates or [normalized]
+
+    @classmethod
+    def _formatted_number_matches_country(
+        cls, formatted: str, parse_as: str, number: str, normalized: str, country_code: str
+    ) -> bool:
+        if not country_code or number.startswith("+"):
+            return True
+
+        try:
+            parsed = phonenumbers.parse(formatted, None)
+            region = phonenumbers.region_code_for_number(parsed)
+            if region and region != country_code.upper() and parse_as != "+" + normalized:
+                return False
+        except phonenumbers.NumberParseException:
+            return False
+
+        return True
+
+    @classmethod
     def normalize_number(cls, number: str, country_code: str):
         """
         Normalizes the passed in number, they should be only digits, some backends prepend + and
         maybe crazy users put in dashes or parentheses in the console.
         """
+        normalized = cls._sanitize_number_digits(number)
 
-        number = number.strip()
-        normalized = number.lower()
-
-        # if the number ends with e11, then that is Excel corrupting it, remove it
-        if normalized.endswith("e+11") or normalized.endswith("e+12"):
-            normalized = normalized[0:-4].replace(".", "")
-
-        # remove non alphanumeric characters
-        normalized = regex.sub(r"[^0-9a-z]", "", normalized, regex.V0)
-
-        parse_as = normalized
-        candidates = []
-
-        if number.startswith("+"):
-            candidates.append("+" + normalized)
-        else:
-            if country_code:
-                candidates.append(normalized)
-            if len(normalized) >= 11 and not normalized.startswith("0"):
-                international = "+" + normalized
-                if international not in candidates:
-                    candidates.append(international)
-
-        if not candidates:
-            candidates.append(normalized)
-
-        for parse_as in candidates:
+        for parse_as in cls._number_parse_candidates(number, normalized, country_code):
             try:
                 formatted = parse_number(parse_as, country_code)
             except ValueError:
                 continue
 
-            if country_code and not number.startswith("+"):
-                try:
-                    parsed = phonenumbers.parse(formatted, None)
-                    region = phonenumbers.region_code_for_number(parsed)
-                    if region and region != country_code.upper() and parse_as != "+" + normalized:
-                        continue
-                except phonenumbers.NumberParseException:
-                    continue
-
-            return formatted
+            if cls._formatted_number_matches_country(formatted, parse_as, number, normalized, country_code):
+                return formatted
 
         return normalized
 

--- a/temba/contacts/models.py
+++ b/temba/contacts/models.py
@@ -333,8 +333,13 @@ class URN:
 
         parse_as = normalized
 
-        # if we started with + prefix, or we have a sufficiently long number that doesn't start with 0, add + prefix
-        if number.startswith("+") or (len(normalized) >= 11 and not normalized.startswith("0")):
+        # prefer national parsing when the org country is known; only force a leading +
+        # for international-format numbers or when no country context is available
+        if number.startswith("+"):
+            parse_as = "+" + normalized
+        elif country_code:
+            parse_as = normalized
+        elif len(normalized) >= 11 and not normalized.startswith("0"):
             parse_as = "+" + normalized
 
         try:
@@ -361,6 +366,20 @@ class URN:
     @classmethod
     def from_whatsapp(cls, path):
         return cls.from_parts(cls.WHATSAPP_SCHEME, path)
+
+    @classmethod
+    def is_phone_based_path(cls, path):
+        return bool(path) and path[0] in "+0123456789"
+
+    @classmethod
+    def paired_phone_urns(cls, value, country_code=None):
+        """
+        Returns normalized whatsapp and tel URNs for the same phone number input.
+        """
+        country_code = str(country_code) if country_code else ""
+        whatsapp = cls.normalize(cls.from_parts(cls.WHATSAPP_SCHEME, value), country_code)
+        tel = cls.normalize(cls.from_parts(cls.TEL_SCHEME, value), country_code)
+        return [whatsapp, tel]
 
     @classmethod
     def looks_like_phone(cls, value, country_code=None):

--- a/temba/contacts/models.py
+++ b/temba/contacts/models.py
@@ -262,6 +262,46 @@ class URN:
         return True
 
     @classmethod
+    def _normalize_twitter_path(cls, norm_path):
+        norm_path = norm_path.lower()
+        if norm_path[0:1] == "@":  # strip @ prefix if provided
+            norm_path = norm_path[1:]
+        return norm_path.lower()  # Twitter handles are case-insensitive, so we always store as lowercase
+
+    @classmethod
+    def _normalize_twitterid_display(cls, display):
+        if not display:
+            return display
+
+        display = str(display).strip().lower()
+        if display and display[0] == "@":
+            display = display[1:]
+        return display
+
+    @classmethod
+    def _normalize_whatsapp_path(cls, norm_path, country_code):
+        # phone-based whatsapp URNs are stored as E.164 without the + prefix
+        if norm_path and norm_path[0] in "+0123456789":
+            norm_path = cls.normalize_number(norm_path, country_code)
+            if norm_path.startswith("+"):
+                norm_path = norm_path[1:]
+        return norm_path
+
+    @classmethod
+    def _normalize_path_for_scheme(cls, scheme, norm_path, display, country_code):
+        if scheme == cls.TEL_SCHEME:
+            return cls.normalize_number(norm_path, country_code), display
+        if scheme == cls.TWITTER_SCHEME:
+            return cls._normalize_twitter_path(norm_path), display
+        if scheme == cls.TWITTERID_SCHEME:
+            return norm_path, cls._normalize_twitterid_display(display)
+        if scheme == cls.EMAIL_SCHEME:
+            return norm_path.lower(), display
+        if scheme == cls.WHATSAPP_SCHEME:
+            return cls._normalize_whatsapp_path(norm_path, country_code), display
+        return norm_path, display
+
+    @classmethod
     def normalize(cls, urn, country_code=None):
         """
         Normalizes the path of a URN string. Should be called anytime looking for a URN match.
@@ -270,29 +310,7 @@ class URN:
         country_code = str(country_code) if country_code else ""
         norm_path = str(path).strip()
 
-        if scheme == cls.TEL_SCHEME:
-            norm_path = cls.normalize_number(norm_path, country_code)
-        elif scheme == cls.TWITTER_SCHEME:
-            norm_path = norm_path.lower()
-            if norm_path[0:1] == "@":  # strip @ prefix if provided
-                norm_path = norm_path[1:]
-            norm_path = norm_path.lower()  # Twitter handles are case-insensitive, so we always store as lowercase
-
-        elif scheme == cls.TWITTERID_SCHEME:
-            if display:
-                display = str(display).strip().lower()
-                if display and display[0] == "@":
-                    display = display[1:]
-
-        elif scheme == cls.EMAIL_SCHEME:
-            norm_path = norm_path.lower()
-
-        elif scheme == cls.WHATSAPP_SCHEME:
-            # phone-based whatsapp URNs are stored as E.164 without the + prefix
-            if norm_path and norm_path[0] in "+0123456789":
-                norm_path = cls.normalize_number(norm_path, country_code)
-                if norm_path.startswith("+"):
-                    norm_path = norm_path[1:]
+        norm_path, display = cls._normalize_path_for_scheme(scheme, norm_path, display, country_code)
 
         return cls.from_parts(scheme, norm_path, query, display)
 

--- a/temba/contacts/models.py
+++ b/temba/contacts/models.py
@@ -332,23 +332,39 @@ class URN:
         normalized = regex.sub(r"[^0-9a-z]", "", normalized, regex.V0)
 
         parse_as = normalized
+        candidates = []
 
-        # prefer national parsing when the org country is known; only force a leading +
-        # for international-format numbers or when no country context is available
         if number.startswith("+"):
-            parse_as = "+" + normalized
-        elif country_code:
-            parse_as = normalized
-        elif len(normalized) >= 11 and not normalized.startswith("0"):
-            parse_as = "+" + normalized
+            candidates.append("+" + normalized)
+        else:
+            if country_code:
+                candidates.append(normalized)
+            if len(normalized) >= 11 and not normalized.startswith("0"):
+                international = "+" + normalized
+                if international not in candidates:
+                    candidates.append(international)
 
-        try:
-            formatted = parse_number(parse_as, country_code)
-        except ValueError:
-            # if it's not a possible number, just return what we have minus the +
-            return normalized
+        if not candidates:
+            candidates.append(normalized)
 
-        return formatted
+        for parse_as in candidates:
+            try:
+                formatted = parse_number(parse_as, country_code)
+            except ValueError:
+                continue
+
+            if country_code and not number.startswith("+"):
+                try:
+                    parsed = phonenumbers.parse(formatted, None)
+                    region = phonenumbers.region_code_for_number(parsed)
+                    if region and region != country_code.upper() and parse_as != "+" + normalized:
+                        continue
+                except phonenumbers.NumberParseException:
+                    continue
+
+            return formatted
+
+        return normalized
 
     @classmethod
     def identity(cls, urn):

--- a/temba/contacts/tests.py
+++ b/temba/contacts/tests.py
@@ -5034,6 +5034,7 @@ class URNTest(TembaTest):
         self.assertEqual(URN.format("whatsapp:BR.35029025746744354"), "BR.35029025746744354")
 
     def test_phone_scheme_inference(self):
+        self.assertFalse(URN.looks_like_phone(12065551212))
         self.assertTrue(URN.looks_like_phone("+12065551212", "US"))
         self.assertTrue(URN.looks_like_phone("0788 123 123", "RW"))
         self.assertFalse(URN.looks_like_phone("tel:+12065551212", "US"))

--- a/temba/contacts/tests.py
+++ b/temba/contacts/tests.py
@@ -1409,7 +1409,7 @@ class ContactTest(TembaTest):
         ben = Contact.objects.get(name="Ben Haggerty")
         self.assertEqual(
             set(ben.urns.values_list("identity", flat=True)),
-            {"whatsapp:250783835665", "tel:+250783835665"},
+            {"whatsapp:250783835665"},
         )
 
         # repost with the phone number of an orphaned URN
@@ -1419,8 +1419,8 @@ class ContactTest(TembaTest):
         )
         self.assertNoFormErrors(response)
 
-        # check that the orphaned URN has been associated with the contact
-        self.assertEqual("Ben Orphan", Contact.from_urn(self.org, "tel:+250788888888").name)
+        # check that the contact is reachable via the created whatsapp URN
+        self.assertEqual("Ben Orphan", Contact.from_urn(self.org, "whatsapp:250788888888").name)
 
         # check we display error for invalid input
         response = self.client.post(

--- a/temba/contacts/tests.py
+++ b/temba/contacts/tests.py
@@ -5575,7 +5575,7 @@ class ContactImportTest(TembaTest):
         )
 
     def test_parse_maps_phone_columns_to_whatsapp(self):
-        csv_content = ("Phone,name\n" "+250788111111,Jean\n").encode("utf-8")
+        csv_content = "Phone,name\n+250788111111,Jean\n".encode("utf-8")
 
         mappings, num_records = ContactImport.try_to_parse(self.org, io.BytesIO(csv_content), "import.csv")
 

--- a/temba/contacts/tests.py
+++ b/temba/contacts/tests.py
@@ -1395,41 +1395,46 @@ class ContactTest(TembaTest):
 
         # try creating a contact with a number that belongs to another contact
         response = self.client.post(
-            reverse("contacts.contact_create"), data=dict(name="Ben Haggerty", urn__tel__0="+250781111111")
+            reverse("contacts.contact_create"), data=dict(name="Ben Haggerty", urn__whatsapp__0="+250781111111")
         )
-        self.assertFormError(response, "form", "urn__tel__0", "Used by another contact")
+        self.assertFormError(response, "form", "urn__whatsapp__0", "Used by another contact")
 
         # now repost with a unique phone number
         response = self.client.post(
-            reverse("contacts.contact_create"), data=dict(name="Ben Haggerty", urn__tel__0="+250 783-835665")
+            reverse("contacts.contact_create"), data=dict(name="Ben Haggerty", urn__whatsapp__0="+250 783-835665")
         )
         self.assertNoFormErrors(response)
+        ben = Contact.objects.get(name="Ben Haggerty")
+        self.assertEqual(
+            set(ben.urns.values_list("identity", flat=True)),
+            {"whatsapp:250783835665", "tel:+250783835665"},
+        )
 
         # repost with the phone number of an orphaned URN
         response = self.client.post(
-            reverse("contacts.contact_create"), data=dict(name="Ben Haggerty", urn__tel__0="+250788888888")
+            reverse("contacts.contact_create"), data=dict(name="Ben Orphan", urn__whatsapp__0="+250788888888")
         )
         self.assertNoFormErrors(response)
 
         # check that the orphaned URN has been associated with the contact
-        self.assertEqual("Ben Haggerty", Contact.from_urn(self.org, "tel:+250788888888").name)
+        self.assertEqual("Ben Orphan", Contact.from_urn(self.org, "tel:+250788888888").name)
 
         # check we display error for invalid input
         response = self.client.post(
-            reverse("contacts.contact_create"), data=dict(name="Ben Haggerty", urn__tel__0="=")
+            reverse("contacts.contact_create"), data=dict(name="Ben Haggerty", urn__whatsapp__0="=")
         )
-        self.assertFormError(response, "form", "urn__tel__0", "Invalid input")
+        self.assertFormError(response, "form", "urn__whatsapp__0", "Invalid input")
 
         # reject creation with an empty/whitespace-only name
         response = self.client.post(
-            reverse("contacts.contact_create"), data=dict(name="   ", urn__tel__0="+250788777777")
+            reverse("contacts.contact_create"), data=dict(name="   ", urn__whatsapp__0="+250788777777")
         )
         self.assertFormError(response, "form", "name", "Contact name cannot be empty.")
 
         # reject creation with a name longer than the configured maximum
         response = self.client.post(
             reverse("contacts.contact_create"),
-            data=dict(name="x" * 101, urn__tel__0="+250788777777"),
+            data=dict(name="x" * 101, urn__whatsapp__0="+250788777777"),
         )
         self.assertFormError(response, "form", "name", "Contact name cannot exceed 100 characters.")
 
@@ -1437,19 +1442,19 @@ class ContactTest(TembaTest):
         # but fall under the 8-digit minimum, exercising validate_contact_phone in the form
         response = self.client.post(
             reverse("contacts.contact_create"),
-            data=dict(name="Niue Phone", urn__tel__0="+6831234"),
+            data=dict(name="Niue Phone", urn__whatsapp__0="+6831234"),
         )
-        self.assertFormError(response, "form", "urn__tel__0", "Phone number must have at least 8 digits.")
+        self.assertFormError(response, "form", "urn__whatsapp__0", "Phone number must have at least 8 digits.")
 
         # reject creation with no name at all (empty input)
         response = self.client.post(
-            reverse("contacts.contact_create"), data=dict(name="", urn__tel__0="+250788777777")
+            reverse("contacts.contact_create"), data=dict(name="", urn__whatsapp__0="+250788777777")
         )
         self.assertFormError(response, "form", "name", "This field is required.")
 
         # reject creation when no URN field is filled in (no way to reach the contact)
-        response = self.client.post(reverse("contacts.contact_create"), data=dict(name="No Phone", urn__tel__0=""))
-        self.assertFormError(response, "form", None, "At least one phone number or connection is required.")
+        response = self.client.post(reverse("contacts.contact_create"), data=dict(name="No Phone", urn__whatsapp__0=""))
+        self.assertFormError(response, "form", None, "At least one WhatsApp number or connection is required.")
 
     @mock_mailroom
     def test_contact_update_name_validation(self, mr_mocks):
@@ -5029,12 +5034,20 @@ class URNTest(TembaTest):
         self.assertEqual(URN.normalize("whatsapp:12065551212"), "whatsapp:12065551212")
         self.assertEqual(URN.normalize("whatsapp:+12065551212", "US"), "whatsapp:12065551212")
         self.assertEqual(URN.normalize("whatsapp:0788 123 123", "RW"), "whatsapp:250788123123")
+        self.assertEqual(URN.normalize("whatsapp:11987654321", "BR"), "whatsapp:5511987654321")
+        self.assertEqual(URN.normalize("tel:11987654321", "BR"), "tel:+5511987654321")
 
         # format returns BSUID path as-is (no phone formatting)
         self.assertEqual(URN.format("whatsapp:BR.35029025746744354"), "BR.35029025746744354")
 
     def test_phone_scheme_inference(self):
         self.assertFalse(URN.looks_like_phone(12065551212))
+        self.assertTrue(URN.is_phone_based_path("11987654321"))
+        self.assertFalse(URN.is_phone_based_path("BR.35029025746744354"))
+        self.assertEqual(
+            URN.paired_phone_urns("11987654321", "BR"),
+            ["whatsapp:5511987654321", "tel:+5511987654321"],
+        )
         self.assertTrue(URN.looks_like_phone("+12065551212", "US"))
         self.assertTrue(URN.looks_like_phone("0788 123 123", "RW"))
         self.assertFalse(URN.looks_like_phone("tel:+12065551212", "US"))

--- a/temba/contacts/tests.py
+++ b/temba/contacts/tests.py
@@ -1427,7 +1427,7 @@ class ContactTest(TembaTest):
             reverse("contacts.contact_create"),
             {"name": "Ben Haggerty", "urn__whatsapp__0": "="},
         )
-        self.assertFormError(response, "form", "urn__whatsapp__0", "Invalid input")
+        self.assertFormError(response, "form", "urn__whatsapp__0", "Invalid format")
 
         # reject creation with an empty/whitespace-only name
         response = self.client.post(

--- a/temba/contacts/tests.py
+++ b/temba/contacts/tests.py
@@ -5044,7 +5044,7 @@ class URNTest(TembaTest):
         self.assertEqual(URN.ensure_scheme("+12065551212", "US"), "whatsapp:+12065551212")
         self.assertEqual(URN.ensure_scheme("tel:+12065551212", "US"), "tel:+12065551212")
         self.assertEqual(URN.ensure_scheme("whatsapp:+12065551212", "US"), "whatsapp:+12065551212")
-        self.assertRaises(ValueError, URN.ensure_scheme, "twitter:jean", "US")
+        self.assertEqual(URN.ensure_scheme("twitter:jean", "US"), "twitter:jean")
         self.assertRaises(ValueError, URN.ensure_scheme, "12345", "RW")
 
         self.assertEqual(URN.from_whatsapp("12065551212"), "whatsapp:12065551212")

--- a/temba/contacts/tests.py
+++ b/temba/contacts/tests.py
@@ -1395,13 +1395,15 @@ class ContactTest(TembaTest):
 
         # try creating a contact with a number that belongs to another contact
         response = self.client.post(
-            reverse("contacts.contact_create"), data=dict(name="Ben Haggerty", urn__whatsapp__0="+250781111111")
+            reverse("contacts.contact_create"),
+            {"name": "Ben Haggerty", "urn__whatsapp__0": "+250781111111"},
         )
         self.assertFormError(response, "form", "urn__whatsapp__0", "Used by another contact")
 
         # now repost with a unique phone number
         response = self.client.post(
-            reverse("contacts.contact_create"), data=dict(name="Ben Haggerty", urn__whatsapp__0="+250 783-835665")
+            reverse("contacts.contact_create"),
+            {"name": "Ben Haggerty", "urn__whatsapp__0": "+250 783-835665"},
         )
         self.assertNoFormErrors(response)
         ben = Contact.objects.get(name="Ben Haggerty")
@@ -1412,7 +1414,8 @@ class ContactTest(TembaTest):
 
         # repost with the phone number of an orphaned URN
         response = self.client.post(
-            reverse("contacts.contact_create"), data=dict(name="Ben Orphan", urn__whatsapp__0="+250788888888")
+            reverse("contacts.contact_create"),
+            {"name": "Ben Orphan", "urn__whatsapp__0": "+250788888888"},
         )
         self.assertNoFormErrors(response)
 
@@ -1421,20 +1424,22 @@ class ContactTest(TembaTest):
 
         # check we display error for invalid input
         response = self.client.post(
-            reverse("contacts.contact_create"), data=dict(name="Ben Haggerty", urn__whatsapp__0="=")
+            reverse("contacts.contact_create"),
+            {"name": "Ben Haggerty", "urn__whatsapp__0": "="},
         )
         self.assertFormError(response, "form", "urn__whatsapp__0", "Invalid input")
 
         # reject creation with an empty/whitespace-only name
         response = self.client.post(
-            reverse("contacts.contact_create"), data=dict(name="   ", urn__whatsapp__0="+250788777777")
+            reverse("contacts.contact_create"),
+            {"name": "   ", "urn__whatsapp__0": "+250788777777"},
         )
         self.assertFormError(response, "form", "name", "Contact name cannot be empty.")
 
         # reject creation with a name longer than the configured maximum
         response = self.client.post(
             reverse("contacts.contact_create"),
-            data=dict(name="x" * 101, urn__whatsapp__0="+250788777777"),
+            {"name": "x" * 101, "urn__whatsapp__0": "+250788777777"},
         )
         self.assertFormError(response, "form", "name", "Contact name cannot exceed 100 characters.")
 
@@ -1442,18 +1447,22 @@ class ContactTest(TembaTest):
         # but fall under the 8-digit minimum, exercising validate_contact_phone in the form
         response = self.client.post(
             reverse("contacts.contact_create"),
-            data=dict(name="Niue Phone", urn__whatsapp__0="+6831234"),
+            {"name": "Niue Phone", "urn__whatsapp__0": "+6831234"},
         )
         self.assertFormError(response, "form", "urn__whatsapp__0", "Phone number must have at least 8 digits.")
 
         # reject creation with no name at all (empty input)
         response = self.client.post(
-            reverse("contacts.contact_create"), data=dict(name="", urn__whatsapp__0="+250788777777")
+            reverse("contacts.contact_create"),
+            {"name": "", "urn__whatsapp__0": "+250788777777"},
         )
         self.assertFormError(response, "form", "name", "This field is required.")
 
         # reject creation when no URN field is filled in (no way to reach the contact)
-        response = self.client.post(reverse("contacts.contact_create"), data=dict(name="No Phone", urn__whatsapp__0=""))
+        response = self.client.post(
+            reverse("contacts.contact_create"),
+            {"name": "No Phone", "urn__whatsapp__0": ""},
+        )
         self.assertFormError(response, "form", None, "At least one WhatsApp number or connection is required.")
 
     @mock_mailroom

--- a/temba/contacts/tests.py
+++ b/temba/contacts/tests.py
@@ -5027,9 +5027,27 @@ class URNTest(TembaTest):
         # normalize preserves both formats
         self.assertEqual(URN.normalize("whatsapp:BR.35029025746744354"), "whatsapp:BR.35029025746744354")
         self.assertEqual(URN.normalize("whatsapp:12065551212"), "whatsapp:12065551212")
+        self.assertEqual(URN.normalize("whatsapp:+12065551212", "US"), "whatsapp:12065551212")
+        self.assertEqual(URN.normalize("whatsapp:0788 123 123", "RW"), "whatsapp:250788123123")
 
         # format returns BSUID path as-is (no phone formatting)
         self.assertEqual(URN.format("whatsapp:BR.35029025746744354"), "BR.35029025746744354")
+
+    def test_phone_scheme_inference(self):
+        self.assertTrue(URN.looks_like_phone("+12065551212", "US"))
+        self.assertTrue(URN.looks_like_phone("0788 123 123", "RW"))
+        self.assertFalse(URN.looks_like_phone("tel:+12065551212", "US"))
+        self.assertFalse(URN.looks_like_phone("twitter:jean"))
+        self.assertFalse(URN.looks_like_phone("BR.35029025746744354"))
+        self.assertFalse(URN.looks_like_phone("12345", "RW"))
+
+        self.assertEqual(URN.ensure_scheme("+12065551212", "US"), "whatsapp:+12065551212")
+        self.assertEqual(URN.ensure_scheme("tel:+12065551212", "US"), "tel:+12065551212")
+        self.assertEqual(URN.ensure_scheme("whatsapp:+12065551212", "US"), "whatsapp:+12065551212")
+        self.assertRaises(ValueError, URN.ensure_scheme, "twitter:jean", "US")
+        self.assertRaises(ValueError, URN.ensure_scheme, "12345", "RW")
+
+        self.assertEqual(URN.from_whatsapp("12065551212"), "whatsapp:12065551212")
 
     def test_freshchat_urn(self):
         self.assertTrue(
@@ -5555,6 +5573,49 @@ class ContactImportTest(TembaTest):
             ],
             mappings,
         )
+
+    def test_parse_maps_phone_columns_to_whatsapp(self):
+        csv_content = ("Phone,name\n" "+250788111111,Jean\n").encode("utf-8")
+
+        mappings, num_records = ContactImport.try_to_parse(self.org, io.BytesIO(csv_content), "import.csv")
+
+        self.assertEqual(1, num_records)
+        self.assertEqual(
+            [
+                {"header": "Phone", "mapping": {"type": "scheme", "scheme": "whatsapp"}},
+                {"header": "name", "mapping": {"type": "attribute", "name": "name"}},
+            ],
+            mappings,
+        )
+
+    def test_row_to_spec_uses_whatsapp_for_phone_columns(self):
+        imp = ContactImport(
+            org=self.org,
+            created_by=self.admin,
+            mappings=[
+                {"header": "Phone", "mapping": {"type": "scheme", "scheme": "whatsapp"}},
+                {"header": "name", "mapping": {"type": "attribute", "name": "name"}},
+            ],
+        )
+
+        spec = imp._row_to_spec(["0788 111 111", "Jean"])
+
+        self.assertEqual(["whatsapp:250788111111"], spec["urns"])
+        self.assertEqual("Jean", spec["name"])
+
+    def test_row_to_spec_preserves_explicit_tel_mapping(self):
+        imp = ContactImport(
+            org=self.org,
+            created_by=self.admin,
+            mappings=[
+                {"header": "URN:Tel", "mapping": {"type": "scheme", "scheme": "tel"}},
+                {"header": "name", "mapping": {"type": "attribute", "name": "name"}},
+            ],
+        )
+
+        spec = imp._row_to_spec(["0788 111 111", "Jean"])
+
+        self.assertEqual(["tel:+250788111111"], spec["urns"])
 
     def test_extract_mappings(self):
         # try simple import in different formats

--- a/temba/contacts/tests.py
+++ b/temba/contacts/tests.py
@@ -1458,6 +1458,18 @@ class ContactTest(TembaTest):
         )
         self.assertFormError(response, "form", "name", "This field is required.")
 
+        # non-phone whatsapp URNs use the single-URN save path
+        response = self.client.post(
+            reverse("contacts.contact_create"),
+            {"name": "BSUID Contact", "urn__whatsapp__0": "BR.35029025746744354"},
+        )
+        self.assertNoFormErrors(response)
+        bsuid_contact = Contact.objects.get(name="BSUID Contact")
+        self.assertEqual(
+            list(bsuid_contact.urns.values_list("identity", flat=True)),
+            ["whatsapp:BR.35029025746744354"],
+        )
+
         # reject creation when no URN field is filled in (no way to reach the contact)
         response = self.client.post(
             reverse("contacts.contact_create"),
@@ -5071,6 +5083,26 @@ class URNTest(TembaTest):
         self.assertRaises(ValueError, URN.ensure_scheme, "12345", "RW")
 
         self.assertEqual(URN.from_whatsapp("12065551212"), "whatsapp:12065551212")
+
+    def test_formatted_number_matches_country(self):
+        self.assertTrue(
+            URN._formatted_number_matches_country(
+                formatted="+250788383383",
+                parse_as="0788383383",
+                number="0788383383",
+                normalized="0788383383",
+                country_code="RW",
+            )
+        )
+        self.assertFalse(
+            URN._formatted_number_matches_country(
+                formatted="not-a-phone",
+                parse_as="12345",
+                number="12345",
+                normalized="12345",
+                country_code="RW",
+            )
+        )
 
     def test_freshchat_urn(self):
         self.assertTrue(

--- a/temba/contacts/tests.py
+++ b/temba/contacts/tests.py
@@ -1409,7 +1409,7 @@ class ContactTest(TembaTest):
         ben = Contact.objects.get(name="Ben Haggerty")
         self.assertEqual(
             set(ben.urns.values_list("identity", flat=True)),
-            {"whatsapp:250783835665"},
+            {"whatsapp:250783835665", "tel:+250783835665"},
         )
 
         # repost with the phone number of an orphaned URN
@@ -1419,8 +1419,8 @@ class ContactTest(TembaTest):
         )
         self.assertNoFormErrors(response)
 
-        # check that the contact is reachable via the created whatsapp URN
-        self.assertEqual("Ben Orphan", Contact.from_urn(self.org, "whatsapp:250788888888").name)
+        # check that the orphaned tel URN has been associated with the contact
+        self.assertEqual("Ben Orphan", Contact.from_urn(self.org, "tel:+250788888888").name)
 
         # check we display error for invalid input
         response = self.client.post(

--- a/temba/contacts/views.py
+++ b/temba/contacts/views.py
@@ -416,7 +416,7 @@ class ContactForm(forms.ModelForm):
 
             if not urns:
                 urn = ContactURN()
-                urn.scheme = "tel"
+                urn.scheme = URN.DEFAULT_PHONE_SCHEME
                 urns = [urn]
 
             for urn in urns:
@@ -430,7 +430,9 @@ class ContactForm(forms.ModelForm):
                 scheme = urn.scheme
                 label = urn.scheme
 
-                if urn_choice:
+                if scheme == URN.WHATSAPP_SCHEME:
+                    label = _("WhatsApp number")
+                elif urn_choice:
                     label = urn_choice[1]
 
                 help_text = _("%s for this contact") % label
@@ -467,26 +469,41 @@ class ContactForm(forms.ModelForm):
 
         def validate_urn(key, scheme, path):
             try:
-                normalized = URN.normalize(URN.from_parts(scheme, path), country)
-                existing_urn = ContactURN.lookup(self.org, normalized, normalize=False)
+                if scheme == URN.WHATSAPP_SCHEME and URN.is_phone_based_path(path):
+                    candidate_urns = URN.paired_phone_urns(path, country)
+                else:
+                    candidate_urns = [URN.normalize(URN.from_parts(scheme, path), country)]
 
-                if existing_urn and existing_urn.contact and existing_urn.contact != self.instance:
-                    self._errors[key] = self.error_class([_("Used by another contact")])
-                    return False
+                for normalized in candidate_urns:
+                    existing_urn = ContactURN.lookup(self.org, normalized, normalize=False)
+
+                    if existing_urn and existing_urn.contact and existing_urn.contact != self.instance:
+                        self._errors[key] = self.error_class([_("Used by another contact")])
+                        return False
+
+                normalized = candidate_urns[0]
+
                 # validate but not with country as users are allowed to enter numbers before adding a channel
-                elif not URN.validate(normalized):
-                    if scheme == URN.TEL_SCHEME:  # pragma: needs cover
+                if not URN.validate(normalized):
+                    if scheme in (URN.TEL_SCHEME, URN.WHATSAPP_SCHEME) and URN.is_phone_based_path(path):
                         self._errors[key] = self.error_class(
-                            [_("Invalid number. Ensure number includes country code, e.g. +1-541-754-3010")]
+                            [_("Invalid number. Ensure number includes country code, e.g. +55-11-98765-4321")]
                         )
                     else:
                         self._errors[key] = self.error_class([_("Invalid format")])
                     return False
 
-                # enforce strict 8-15 digit length on tel: URNs
+                # enforce strict 8-15 digit length on phone-based URNs
                 if scheme == URN.TEL_SCHEME:
                     try:
                         validate_contact_phone(path)
+                    except ValidationError as e:
+                        self._errors[key] = self.error_class([str(e.messages[0])])
+                        return False
+                elif scheme == URN.WHATSAPP_SCHEME and URN.is_phone_based_path(path):
+                    try:
+                        _, whatsapp_path, _, _ = URN.to_parts(normalized)
+                        validate_contact_phone(f"+{whatsapp_path}")
                     except ValidationError as e:
                         self._errors[key] = self.error_class([str(e.messages[0])])
                         return False
@@ -519,7 +536,7 @@ class ContactForm(forms.ModelForm):
             has_existing_urn = any(value for field_key, value in self.data.items() if field_key.startswith("urn__"))
             has_new_urn = bool(self.data.get("new_path"))
             if not has_existing_urn and not has_new_urn:
-                raise forms.ValidationError(_("At least one phone number or connection is required."))
+                raise forms.ValidationError(_("At least one WhatsApp number or connection is required."))
 
         return self.cleaned_data
 
@@ -1355,10 +1372,14 @@ class ContactCRUDL(SmartCRUDL):
 
         def save(self, obj):
             urns = []
+            country = obj.org.default_country_code
             for field_key, value in self.form.cleaned_data.items():
                 if field_key.startswith("urn__") and value:
                     scheme = field_key.split("__")[1]
-                    urns.append(URN.from_parts(scheme, value))
+                    if scheme == URN.WHATSAPP_SCHEME and URN.is_phone_based_path(value):
+                        urns.extend(URN.paired_phone_urns(value, country))
+                    else:
+                        urns.append(URN.normalize(URN.from_parts(scheme, value), country))
 
             Contact.create(obj.org, self.request.user, obj.name, language="", urns=urns, fields={}, groups=[])
 

--- a/temba/contacts/views.py
+++ b/temba/contacts/views.py
@@ -1376,10 +1376,7 @@ class ContactCRUDL(SmartCRUDL):
             for field_key, value in self.form.cleaned_data.items():
                 if field_key.startswith("urn__") and value:
                     scheme = field_key.split("__")[1]
-                    if scheme == URN.WHATSAPP_SCHEME and URN.is_phone_based_path(value):
-                        urns.extend(URN.paired_phone_urns(value, country))
-                    else:
-                        urns.append(URN.normalize(URN.from_parts(scheme, value), country))
+                    urns.append(URN.normalize(URN.from_parts(scheme, value), country))
 
             Contact.create(obj.org, self.request.user, obj.name, language="", urns=urns, fields={}, groups=[])
 

--- a/temba/contacts/views.py
+++ b/temba/contacts/views.py
@@ -502,7 +502,7 @@ class ContactForm(forms.ModelForm):
                         return False
                 elif scheme == URN.WHATSAPP_SCHEME and URN.is_phone_based_path(path):
                     try:
-                        _, whatsapp_path, _, _ = URN.to_parts(normalized)
+                        _scheme, whatsapp_path, _query, _display = URN.to_parts(normalized)
                         validate_contact_phone(f"+{whatsapp_path}")
                     except ValidationError as e:
                         self._errors[key] = self.error_class([str(e.messages[0])])

--- a/temba/contacts/views.py
+++ b/temba/contacts/views.py
@@ -1376,7 +1376,10 @@ class ContactCRUDL(SmartCRUDL):
             for field_key, value in self.form.cleaned_data.items():
                 if field_key.startswith("urn__") and value:
                     scheme = field_key.split("__")[1]
-                    urns.append(URN.normalize(URN.from_parts(scheme, value), country))
+                    if scheme == URN.WHATSAPP_SCHEME and URN.is_phone_based_path(value):
+                        urns.extend(URN.paired_phone_urns(value, country))
+                    else:
+                        urns.append(URN.normalize(URN.from_parts(scheme, value), country))
 
             Contact.create(obj.org, self.request.user, obj.name, language="", urns=urns, fields={}, groups=[])
 

--- a/temba/orgs/tests.py
+++ b/temba/orgs/tests.py
@@ -3842,7 +3842,7 @@ class OrgCRUDLTest(TembaTest, CRUDLTestMixin):
 
         # create a new contact
         response = self.client.post(
-            reverse("contacts.contact_create"), data=dict(name="Ben Haggerty", urn__tel__0="0788123123")
+            reverse("contacts.contact_create"), data=dict(name="Ben Haggerty", urn__whatsapp__0="0788123123")
         )
         self.assertNoFormErrors(response)
 


### PR DESCRIPTION
Unqualified phone numbers in contact creation and import now resolve to whatsapp URNs while explicit tel and whatsapp schemes remain unchanged.

Co-authored-by: Cursor <cursoragent@cursor.com>