### PR TITLE
feat: Extend InternalChannelView with billing dual auth and additive fields

### DIFF
--- a/WENI-CHANGELOG.md
+++ b/WENI-CHANGELOG.md
@@ -1,3 +1,7 @@
+3.83.1
+----------
+* feat: extend InternalChannelView with billing dual auth and additive fields
+
 3.83.0
 ----------
 * feat: default bare phone URNs to whatsapp on API, import and contact create form

--- a/temba/api/auth/billing.py
+++ b/temba/api/auth/billing.py
@@ -1,0 +1,37 @@
+from rest_framework.authentication import BaseAuthentication
+from rest_framework.exceptions import AuthenticationFailed
+from rest_framework.permissions import BasePermission
+
+from django.conf import settings
+from django.contrib.auth.models import AnonymousUser
+
+
+class BillingFixedAccessTokenAuthentication(BaseAuthentication):
+    """
+    Service-to-service auth via the shared BILLING_FIXED_ACCESS_TOKEN query param.
+
+    Mirrors the inline token check previously used by ChannelProjectView and InternalContactView,
+    but as a DRF authenticator so it can compose with InternalOIDCAuthentication.
+    """
+
+    def authenticate(self, request):
+        token = request.query_params.get("token")
+        if token is None:
+            return None
+
+        billing_token = getattr(settings, "BILLING_FIXED_ACCESS_TOKEN", None)
+        if not billing_token or token != billing_token:
+            raise AuthenticationFailed()
+
+        request.billing_fixed_access_authenticated = True
+        return (AnonymousUser(), None)
+
+
+class HasBillingFixedAccessToken(BasePermission):
+    def has_permission(self, request, view):
+        return getattr(request, "billing_fixed_access_authenticated", False)
+
+
+class BillingFixedAccessTokenViewMixin:
+    authentication_classes = [BillingFixedAccessTokenAuthentication]
+    permission_classes = [HasBillingFixedAccessToken]

--- a/temba/api/tests/test_billing_auth.py
+++ b/temba/api/tests/test_billing_auth.py
@@ -1,0 +1,46 @@
+from rest_framework.exceptions import AuthenticationFailed
+from rest_framework.test import APIRequestFactory
+
+from django.contrib.auth.models import AnonymousUser
+from django.test import TestCase, override_settings
+
+from temba.api.auth.billing import BillingFixedAccessTokenAuthentication, HasBillingFixedAccessToken
+
+
+class BillingFixedAccessTokenAuthenticationTests(TestCase):
+    def setUp(self):
+        self.factory = APIRequestFactory()
+        self.auth = BillingFixedAccessTokenAuthentication()
+
+    def test_no_token_returns_none(self):
+        request = self.factory.get("/")
+        self.assertIsNone(self.auth.authenticate(request))
+
+    @override_settings(BILLING_FIXED_ACCESS_TOKEN="12345")
+    def test_invalid_token_raises(self):
+        request = self.factory.get("/?token=invalid")
+        with self.assertRaises(AuthenticationFailed):
+            self.auth.authenticate(request)
+
+    @override_settings(BILLING_FIXED_ACCESS_TOKEN="12345")
+    def test_valid_token_authenticates(self):
+        request = self.factory.get("/?token=12345")
+        user, auth = self.auth.authenticate(request)
+        self.assertIsInstance(user, AnonymousUser)
+        self.assertIsNone(auth)
+        self.assertTrue(request.billing_fixed_access_authenticated)
+
+
+class HasBillingFixedAccessTokenTests(TestCase):
+    def setUp(self):
+        self.factory = APIRequestFactory()
+        self.permission = HasBillingFixedAccessToken()
+
+    def test_denies_without_flag(self):
+        request = self.factory.get("/")
+        self.assertFalse(self.permission.has_permission(request, view=None))
+
+    def test_allows_with_flag(self):
+        request = self.factory.get("/")
+        request.billing_fixed_access_authenticated = True
+        self.assertTrue(self.permission.has_permission(request, view=None))

--- a/temba/api/v2/internals/channels/tests/test_views.py
+++ b/temba/api/v2/internals/channels/tests/test_views.py
@@ -5,6 +5,7 @@ from weni.internal.models import Project
 
 from django.test import override_settings
 
+from temba.api.auth.billing import BillingFixedAccessTokenAuthentication, HasBillingFixedAccessToken
 from temba.api.v2.internals.views import JWTAuthMockMixin
 from temba.tests import TembaTest
 
@@ -256,9 +257,88 @@ class InternalChannelViewTest(TembaTest):
         normal = next(c for c in data["results"] if c["uuid"] == str(channel.uuid))
         self.assertEqual(normal["channel_type"], "TG")
         self.assertEqual(normal["name"], "Test Channel")
+        self.assertTrue(normal["is_active"])
+        self.assertIsNone(normal["waba"])
+        self.assertIsNone(normal["phone_number"])
+        self.assertFalse(normal["config"]["is_demo"])
+        self.assertNotIn("MMLite", normal)
         wac = next(c for c in data["results"] if c["uuid"] == str(channel_wac.uuid))
         self.assertEqual(wac["channel_type"], "WAC")
         self.assertEqual(wac["name"], "Test WAC Channel")
         self.assertEqual(wac["waba"], "12345678910")
         self.assertEqual(wac["phone_number"], "+55 00 900001234")
         self.assertTrue(wac["MMLite"])
+        self.assertTrue(wac["is_active"])
+        self.assertEqual(wac["config"]["wa_waba_id"], "12345678910")
+        self.assertEqual(wac["config"]["wa_number"], "+55 00 900001234")
+        self.assertFalse(wac["config"]["is_demo"])
+
+
+class InternalChannelViewBillingTokenTest(TembaTest):
+    """Exercises the billing-token auth path on InternalChannelView.
+
+    OIDC is stripped from authentication_classes because CI has no OIDC settings
+    and instantiating InternalOIDCAuthentication raises ImproperlyConfigured.
+    """
+
+    def setUp(self):
+        super().setUp()
+        self.url = "/api/v2/internals/channels-by-project"
+        auth_patch = patch(
+            "temba.api.v2.internals.channels.views.InternalChannelView.authentication_classes",
+            [BillingFixedAccessTokenAuthentication],
+        )
+        perm_patch = patch(
+            "temba.api.v2.internals.channels.views.InternalChannelView.permission_classes",
+            [HasBillingFixedAccessToken],
+        )
+        auth_patch.start()
+        perm_patch.start()
+        self.addCleanup(auth_patch.stop)
+        self.addCleanup(perm_patch.stop)
+
+    def test_request_without_token(self):
+        response = self.client.get(self.url)
+        self.assertEqual(response.status_code, 403)
+
+    def test_request_with_invalid_token(self):
+        response = self.client.get(f"{self.url}?token=invalidtoken")
+        self.assertEqual(response.status_code, 403)
+
+    def test_request_without_project_uuid(self):
+        with override_settings(BILLING_FIXED_ACCESS_TOKEN="12345"):
+            response = self.client.get(f"{self.url}?token=12345")
+            self.assertEqual(response.status_code, 400)
+            self.assertEqual(response.json(), {"error": "project_uuid is required"})
+
+    def test_returns_active_channels_for_project(self):
+        with override_settings(BILLING_FIXED_ACCESS_TOKEN="12345"):
+            project = Project.objects.create(name="Test project", created_by=self.user, modified_by=self.user)
+            active = self.create_channel("TG", "Active Channel", "active", org=project.org)
+            wac = self.create_channel("WAC", "WAC Channel", "74123456789", org=project.org)
+            wac.config = {
+                "wa_waba_id": "waba-1",
+                "wa_number": "+5500900001234",
+                "is_demo": True,
+            }
+            wac.save()
+            inactive = self.create_channel("TG", "Inactive Channel", "inactive", org=project.org)
+            inactive.is_active = False
+            inactive.save()
+
+            url = f"{self.url}?token=12345&project_uuid={project.project_uuid}"
+            response = self.client.get(url)
+            data = response.json()
+
+            self.assertEqual(response.status_code, 200)
+            self.assertIn("results", data)
+            uuids = {entry["uuid"] for entry in data["results"]}
+            self.assertIn(str(active.uuid), uuids)
+            self.assertIn(str(wac.uuid), uuids)
+            self.assertNotIn(str(inactive.uuid), uuids)
+
+            wac_entry = next(entry for entry in data["results"] if entry["uuid"] == str(wac.uuid))
+            self.assertEqual(wac_entry["channel_type"], "WAC")
+            self.assertEqual(wac_entry["waba"], "waba-1")
+            self.assertEqual(wac_entry["phone_number"], "+5500900001234")
+            self.assertTrue(wac_entry["config"]["is_demo"])

--- a/temba/api/v2/internals/channels/views.py
+++ b/temba/api/v2/internals/channels/views.py
@@ -1,12 +1,14 @@
-from rest_framework.exceptions import AuthenticationFailed, NotAuthenticated
 from rest_framework.permissions import IsAuthenticated
 from rest_framework.request import Request
 from rest_framework.response import Response
 from rest_framework.views import APIView
 from weni.internal.authenticators import InternalOIDCAuthentication
 
-from django.conf import settings
-
+from temba.api.auth.billing import (
+    BillingFixedAccessTokenAuthentication,
+    BillingFixedAccessTokenViewMixin,
+    HasBillingFixedAccessToken,
+)
 from temba.api.auth.jwt import RequiredJWTAuthentication
 from temba.api.v2.internals.channels.serializers import ChannelElevenLabsApiKeySerializer, ChannelProjectSerializer
 from temba.api.v2.internals.channels.usecases import GetElevenLabsApiKeyUseCase
@@ -15,17 +17,8 @@ from temba.api.v2.permissions import HasValidJWT, IsUserInOrg
 from temba.channels.models import Channel
 
 
-class ChannelProjectView(APIViewMixin, APIView):
+class ChannelProjectView(BillingFixedAccessTokenViewMixin, APIViewMixin, APIView):
     def post(self, request: Request):
-        params = request.query_params
-        token = params.get("token")
-
-        if token is None:
-            raise NotAuthenticated()
-
-        if token != settings.BILLING_FIXED_ACCESS_TOKEN:
-            raise AuthenticationFailed()
-
         serializer = ChannelProjectSerializer(data=request.data)
         serializer.is_valid(raise_exception=True)
         channels_uuids = serializer.validated_data.get("channels")
@@ -54,8 +47,8 @@ class ChannelProjectView(APIViewMixin, APIView):
 
 
 class InternalChannelView(APIViewMixin, APIView):
-    authentication_classes = [InternalOIDCAuthentication]
-    permission_classes = [IsAuthenticated, IsUserInOrg]
+    authentication_classes = [BillingFixedAccessTokenAuthentication, InternalOIDCAuthentication]
+    permission_classes = [(IsAuthenticated & IsUserInOrg) | HasBillingFixedAccessToken]
 
     def get(self, request: Request):
         org = self.get_org_from_request(
@@ -67,24 +60,29 @@ class InternalChannelView(APIViewMixin, APIView):
         if isinstance(org, Response):
             return org
 
-        response = {"results": []}
-
         channels = Channel.objects.filter(org=org, is_active=True)
-        for channel in channels:
-            channel_data = {
-                "uuid": str(channel.uuid),
-                "channel_type": channel.channel_type,
-                "name": channel.name,
-            }
-            if channel.channel_type == "WAC":
-                channel_data["waba"] = channel.config.get("wa_waba_id") if channel.config.get("wa_waba_id") else None
-                channel_data["phone_number"] = (
-                    channel.config.get("wa_number") if channel.config.get("wa_number") else None
-                )
-                channel_data["MMLite"] = True if channel.config.get("mmlite") else False
-            response["results"].append(channel_data)
+        results = [self._serialize_channel(channel) for channel in channels]
+        return Response({"results": results})
 
-        return Response(response)
+    @staticmethod
+    def _serialize_channel(channel):
+        config = channel.config or {}
+        channel_data = {
+            "uuid": str(channel.uuid),
+            "channel_type": channel.channel_type,
+            "name": channel.name,
+            "is_active": channel.is_active,
+            "waba": config.get("wa_waba_id") or None,
+            "phone_number": config.get("wa_number") or None,
+            "config": {
+                "wa_waba_id": config.get("wa_waba_id"),
+                "wa_number": config.get("wa_number"),
+                "is_demo": bool(config.get("is_demo", False)),
+            },
+        }
+        if channel.channel_type == "WAC":
+            channel_data["MMLite"] = True if config.get("mmlite") else False
+        return channel_data
 
 
 class ChannelAllowedDomainsView(APIViewMixin, APIView):

--- a/temba/api/v2/internals/contacts/views.py
+++ b/temba/api/v2/internals/contacts/views.py
@@ -5,7 +5,6 @@ from typing import Optional
 
 import pyexcel
 from rest_framework import status
-from rest_framework.exceptions import AuthenticationFailed, NotAuthenticated
 from rest_framework.pagination import CursorPagination
 from rest_framework.parsers import FormParser, JSONParser, MultiPartParser
 from rest_framework.permissions import IsAuthenticated
@@ -29,6 +28,7 @@ from django.utils import timezone
 from django.utils.dateparse import parse_date, parse_datetime
 from django.utils.decorators import method_decorator
 
+from temba.api.auth.billing import BillingFixedAccessTokenViewMixin
 from temba.api.auth.jwt import BaseJWTAuthentication, OptionalJWTAuthentication, RequiredJWTAuthentication
 from temba.api.v2.internals.contacts.serializers import (
     CleanContactFieldsSerializer,
@@ -61,17 +61,8 @@ logger = logging.getLogger(__name__)
 User = get_user_model()
 
 
-class InternalContactView(APIViewMixin, APIView):
+class InternalContactView(BillingFixedAccessTokenViewMixin, APIViewMixin, APIView):
     def post(self, request: Request):
-        params = request.query_params
-        token = params.get("token")
-
-        if token is None:
-            raise NotAuthenticated()
-
-        if token != settings.BILLING_FIXED_ACCESS_TOKEN:
-            raise AuthenticationFailed()
-
         serializer = InternalContactSerializer(data=request.data)
         serializer.is_valid(raise_exception=True)
         contacts_uuids = serializer.validated_data.get("contacts")


### PR DESCRIPTION
## What

- Add shared billing auth module (`BillingFixedAccessTokenAuthentication`, `BillingFixedAccessTokenViewMixin`)
- Extend `InternalChannelView` with dual auth (OIDC or `BILLING_FIXED_ACCESS_TOKEN`)
- Add additive response fields (`is_active`, `config`) without changing existing fields
- Refactor `ChannelProjectView` and `InternalContactView` to use the shared billing mixin
- Add tests for billing auth and new channel response fields

## Why

The billing entity-sync cascade needs to list all active channels of a project in a single call using the billing fixed access token, without introducing a separate endpoint. Existing microservices authenticated via OIDC must keep working with the same contract.
