### PR TITLE
feat: add ChannelMarketingTags functionality

### DIFF
--- a/WENI-CHANGELOG.md
+++ b/WENI-CHANGELOG.md
@@ -1,3 +1,7 @@
+3.84.0
+----------
+* feat: add ChannelMarketingTags functionality
+
 3.83.0
 ----------
 * feat: default bare phone URNs to whatsapp on API, import and contact create form

--- a/temba/api/v2/internals/channels/serializers.py
+++ b/temba/api/v2/internals/channels/serializers.py
@@ -7,3 +7,7 @@ class ChannelProjectSerializer(serializers.Serializer):
 
 class ChannelElevenLabsApiKeySerializer(serializers.Serializer):
     channel_uuid = serializers.UUIDField(required=True)
+
+
+class ChannelMarketingTagsSerializer(serializers.Serializer):
+    channel_uuid = serializers.UUIDField(required=True)

--- a/temba/api/v2/internals/channels/tests/test_usecases.py
+++ b/temba/api/v2/internals/channels/tests/test_usecases.py
@@ -3,6 +3,7 @@ import uuid
 from temba.api.v2.internals.channels.usecases import (
     ChannelNotFoundError,
     ElevenLabsApiKeyNotFoundError,
+    GetChannelMarketingTagsUseCase,
     GetElevenLabsApiKeyUseCase,
 )
 from temba.tests import TembaTest
@@ -41,3 +42,28 @@ class GetElevenLabsApiKeyUseCaseTest(TembaTest):
         )
         result = self.usecase.execute(str(channel.uuid))
         self.assertEqual(result, "sk-test-key-123")
+
+
+class GetChannelMarketingTagsUseCaseTest(TembaTest):
+    def setUp(self):
+        super().setUp()
+        self.usecase = GetChannelMarketingTagsUseCase()
+
+    def test_raises_channel_not_found_for_nonexistent_uuid(self):
+        with self.assertRaises(ChannelNotFoundError):
+            self.usecase.execute(str(uuid.uuid4()))
+
+    def test_returns_false_when_config_missing(self):
+        channel = self.create_channel("WWC", "Test Channel", "test")
+        result = self.usecase.execute(str(channel.uuid))
+        self.assertFalse(result)
+
+    def test_returns_false_when_config_is_false(self):
+        channel = self.create_channel("WWC", "Test Channel", "test", config={"marketing_tags": False})
+        result = self.usecase.execute(str(channel.uuid))
+        self.assertFalse(result)
+
+    def test_returns_true_when_config_is_true(self):
+        channel = self.create_channel("WWC", "Test Channel", "test", config={"marketing_tags": True})
+        result = self.usecase.execute(str(channel.uuid))
+        self.assertTrue(result)

--- a/temba/api/v2/internals/channels/tests/test_views.py
+++ b/temba/api/v2/internals/channels/tests/test_views.py
@@ -194,6 +194,48 @@ class ChannelElevenLabsApiKeyViewTest(PatchedJWTAuthMixin, TembaTest):
         self.assertEqual(response.json(), {"api_key": "sk-test-key-123"})
 
 
+class ChannelMarketingTagsViewTest(PatchedJWTAuthMixin, TembaTest):
+    def setUp(self):
+        super().setUp()
+        self.url = "/api/v2/internals/channel_marketing_tags"
+        self.jwt_payload_patch = {}
+
+    def _set_jwt_payload(self, **kwargs):
+        self.jwt_payload_patch = kwargs
+
+    def test_request_without_channel_uuid(self):
+        self._set_jwt_payload(channel_uuid=None)
+        response = self.client.get(self.url, **self.auth_headers)
+
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(response.json(), {"channel_uuid": ["This field may not be null."]})
+
+    def test_request_with_nonexistent_channel_uuid(self):
+        self._set_jwt_payload(channel_uuid=str(uuid.uuid4()))
+        response = self.client.get(self.url, **self.auth_headers)
+
+        self.assertEqual(response.status_code, 404)
+        self.assertEqual(response.json(), {"detail": "Channel not found"})
+
+    def test_request_returns_false_when_config_missing(self):
+        channel = self.create_channel("WWC", "Test Channel", "test")
+
+        self._set_jwt_payload(channel_uuid=str(channel.uuid))
+        response = self.client.get(self.url, **self.auth_headers)
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.json(), {"marketing_tags": False})
+
+    def test_request_returns_true_when_config_enabled(self):
+        channel = self.create_channel("WWC", "Test Channel", "test", config={"marketing_tags": True})
+
+        self._set_jwt_payload(channel_uuid=str(channel.uuid))
+        response = self.client.get(self.url, **self.auth_headers)
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.json(), {"marketing_tags": True})
+
+
 class InternalChannelViewTest(TembaTest):
     def setUp(self):
         super().setUp()

--- a/temba/api/v2/internals/channels/urls.py
+++ b/temba/api/v2/internals/channels/urls.py
@@ -1,10 +1,17 @@
 from django.urls import path
 
-from .views import ChannelAllowedDomainsView, ChannelElevenLabsApiKeyView, ChannelProjectView, InternalChannelView
+from .views import (
+    ChannelAllowedDomainsView,
+    ChannelElevenLabsApiKeyView,
+    ChannelMarketingTagsView,
+    ChannelProjectView,
+    InternalChannelView,
+)
 
 urlpatterns = [
     path("channel_projects", ChannelProjectView.as_view(), name="channel_projects"),
     path("channels-by-project", InternalChannelView.as_view(), name="channels-by-project"),
     path("channel_allowed_domains", ChannelAllowedDomainsView.as_view(), name="channel_allowed_domains"),
     path("elevenlabs_api_key", ChannelElevenLabsApiKeyView.as_view(), name="elevenlabs_api_key"),
+    path("channel_marketing_tags", ChannelMarketingTagsView.as_view(), name="channel_marketing_tags"),
 ]

--- a/temba/api/v2/internals/channels/usecases.py
+++ b/temba/api/v2/internals/channels/usecases.py
@@ -26,3 +26,13 @@ class GetElevenLabsApiKeyUseCase:
             raise ElevenLabsApiKeyNotFoundError()
 
         return api_key
+
+
+class GetChannelMarketingTagsUseCase:
+    def execute(self, channel_uuid: str) -> bool:
+        try:
+            channel = Channel.objects.get(uuid=channel_uuid)
+        except Channel.DoesNotExist:
+            raise ChannelNotFoundError()
+
+        return bool(channel.config.get("marketing_tags", False))

--- a/temba/api/v2/internals/channels/views.py
+++ b/temba/api/v2/internals/channels/views.py
@@ -8,8 +8,12 @@ from weni.internal.authenticators import InternalOIDCAuthentication
 from django.conf import settings
 
 from temba.api.auth.jwt import RequiredJWTAuthentication
-from temba.api.v2.internals.channels.serializers import ChannelElevenLabsApiKeySerializer, ChannelProjectSerializer
-from temba.api.v2.internals.channels.usecases import GetElevenLabsApiKeyUseCase
+from temba.api.v2.internals.channels.serializers import (
+    ChannelElevenLabsApiKeySerializer,
+    ChannelMarketingTagsSerializer,
+    ChannelProjectSerializer,
+)
+from temba.api.v2.internals.channels.usecases import GetChannelMarketingTagsUseCase, GetElevenLabsApiKeyUseCase
 from temba.api.v2.internals.views import APIViewMixin
 from temba.api.v2.permissions import HasValidJWT, IsUserInOrg
 from temba.channels.models import Channel
@@ -122,3 +126,18 @@ class ChannelElevenLabsApiKeyView(APIViewMixin, APIView):
         api_key = usecase.execute(serializer.validated_data["channel_uuid"])
 
         return Response({"api_key": api_key})
+
+
+class ChannelMarketingTagsView(APIViewMixin, APIView):
+    authentication_classes = [RequiredJWTAuthentication]
+    permission_classes = [HasValidJWT]
+
+    def get(self, request: Request):
+        channel_uuid = getattr(request, "channel_uuid", None)
+        serializer = ChannelMarketingTagsSerializer(data={"channel_uuid": channel_uuid})
+        serializer.is_valid(raise_exception=True)
+
+        usecase = GetChannelMarketingTagsUseCase()
+        marketing_tags = usecase.execute(serializer.validated_data["channel_uuid"])
+
+        return Response({"marketing_tags": marketing_tags})


### PR DESCRIPTION
- Introduced ChannelMarketingTagsSerializer for handling marketing tags.
- Added ChannelMarketingTagsView to retrieve marketing tags for a channel.
- Implemented GetChannelMarketingTagsUseCase to encapsulate the logic for fetching marketing tags.
- Updated URL routing to include the new marketing tags endpoint.
- Added unit tests for GetChannelMarketingTagsUseCase to ensure correct behavior.