### PR TITLE
feat: add marketing_opt_in field to contact updates

### DIFF
--- a/temba/api/v2/internals/contacts/serializers.py
+++ b/temba/api/v2/internals/contacts/serializers.py
@@ -18,7 +18,9 @@ User = get_user_model()
 logger = logging.getLogger(__name__)
 
 # Keys that update_contacts_fields may auto-create as text user fields when missing (org under field limit).
-FALLBACK_AUTO_CREATE_CONTACT_FIELD_KEYS = frozenset({"segment", "orderform", "email", "session", "vtex_account", "marketing_opt_in"})
+FALLBACK_AUTO_CREATE_CONTACT_FIELD_KEYS = frozenset(
+    {"segment", "orderform", "email", "session", "vtex_account", "marketing_opt_in"}
+)
 FALLBACK_AUTO_CREATE_CONTACT_FIELD_LABELS = {
     "segment": "segment",
     "orderform": "orderform",

--- a/temba/api/v2/internals/contacts/serializers.py
+++ b/temba/api/v2/internals/contacts/serializers.py
@@ -18,20 +18,21 @@ User = get_user_model()
 logger = logging.getLogger(__name__)
 
 # Keys that update_contacts_fields may auto-create as text user fields when missing (org under field limit).
-FALLBACK_AUTO_CREATE_CONTACT_FIELD_KEYS = frozenset({"segment", "orderform", "email", "session", "vtex_account"})
+FALLBACK_AUTO_CREATE_CONTACT_FIELD_KEYS = frozenset({"segment", "orderform", "email", "session", "vtex_account", "marketing_opt_in"})
 FALLBACK_AUTO_CREATE_CONTACT_FIELD_LABELS = {
     "segment": "segment",
     "orderform": "orderform",
     "email": "email",
     "session": "session",
     "vtex_account": "vtex_account",
+    "marketing_opt_in": "marketing_opt_in",
 }
 
 
 def _resolve_contact_field_for_update(org, user, raw_key):
     """
     Resolve a ContactField for PATCH update_contacts_fields. Unknown keys are ignored unless they are
-    segment, orderform, email, session or vtex_account: then we create a text field if missing and the org is under its field limit.
+    segment, orderform, email, session, vtex_account or marketing_opt_in: then we create a text field if missing and the org is under its field limit.
     """
     canonical = raw_key.lower()
     field = ContactField.user_fields.active_for_org(org=org).filter(key=raw_key).first()

--- a/temba/api/v2/internals/contacts/tests.py
+++ b/temba/api/v2/internals/contacts/tests.py
@@ -895,6 +895,31 @@ class UpdateContactFieldsViewTest(TembaTest):
     @mock_mailroom
     @override_settings(INTERNAL_USER_EMAIL="super@user.com")
     @patch.object(LambdaURLValidator, "protected_resource")
+    def test_fallback_creates_marketing_opt_in_when_missing(self, mr_mocks, mock_protected_resource):
+        contact = self.create_contact("Marketing Opt-in Test", urns=["twitterid:77777"])
+        self.assertFalse(ContactField.user_fields.filter(org=self.org, key="marketing_opt_in").exists())
+
+        mock_protected_resource.return_value = Response({"message": "Access granted!"}, status=status.HTTP_200_OK)
+
+        url = "/api/v2/internals/update_contacts_fields"
+        body = {
+            "project": self.org.proj_uuid,
+            "contact_urn": "twitterid:77777",
+            "contact_fields": {"marketing_opt_in": "false"},
+        }
+
+        response = self.client.patch(url, data=body, content_type="application/json")
+
+        self.assertEqual(response.status_code, 200)
+        self.assertTrue(ContactField.user_fields.filter(org=self.org, key="marketing_opt_in").exists())
+
+        contact.refresh_from_db()
+        field = ContactField.get_by_key(self.org, "marketing_opt_in")
+        self.assertEqual(contact.get_field_display(field), "false")
+
+    @mock_mailroom
+    @override_settings(INTERNAL_USER_EMAIL="super@user.com")
+    @patch.object(LambdaURLValidator, "protected_resource")
     def test_fallback_creates_session_when_missing(self, mr_mocks, mock_protected_resource):
         contact = self.create_contact("Session Test", urns=["twitterid:66666"])
         self.assertFalse(ContactField.user_fields.filter(org=self.org, key="session").exists())


### PR DESCRIPTION
- Updated FALLBACK_AUTO_CREATE_CONTACT_FIELD_KEYS to include "marketing_opt_in".
- Enhanced _resolve_contact_field_for_update to create a text field for "marketing_opt_in" if missing and the organization is under its field limit.
- Added a test to verify that the marketing_opt_in field is created when missing during contact updates.