### PR TITLE
feat: improve inspect flows command to filter by org or flow uuid

### DIFF
--- a/temba/flows/management/commands/inspect_flows.py
+++ b/temba/flows/management/commands/inspect_flows.py
@@ -1,41 +1,146 @@
-from django.core.management.base import BaseCommand
+from django.core.management.base import BaseCommand, CommandError
 
 from temba import mailroom
 from temba.flows.models import Flow
 from temba.mailroom.client import FlowValidationException
+from temba.orgs.models import Org
 
 
-def inspect_flows():
+def resolve_org(org_identifier):
+    """
+    Resolve an org by numeric id, org uuid, or project uuid (proj_uuid).
+    """
+    try:
+        return Org.objects.get(id=int(org_identifier))
+    except (ValueError, Org.DoesNotExist):
+        pass
+
+    try:
+        return Org.objects.get(proj_uuid=org_identifier)
+    except (ValueError, Org.DoesNotExist):
+        pass
+
+    try:
+        return Org.objects.get(uuid=org_identifier)
+    except (ValueError, Org.DoesNotExist):
+        pass
+
+    raise CommandError(f"No such org matching '{org_identifier}'")
+
+
+def get_flow_queryset(*, org=None, flow_uuid=None):
+    if flow_uuid:
+        return Flow.objects.filter(uuid=flow_uuid).order_by("id")
+
+    flows = Flow.objects.filter(is_active=True)
+    if org:
+        flows = flows.filter(org=org)
+
+    return flows.order_by("id")
+
+
+def _inspect_flow(client, flow):
+    return client.flow_inspect(flow.org_id, flow.get_definition())
+
+
+def _report_inspection_error(flow, stdout, exc):
+    if not stdout:
+        return
+
+    if isinstance(exc, FlowValidationException):
+        stdout.write(f" Invalid: {flow.uuid} {flow.name}")
+        return
+
+    stdout.write(f" Unreadable: {flow.uuid} {flow.name} ({type(exc).__name__}: {exc})")
+
+
+def _sync_has_issues(flow, flow_info, dry_run, stdout):
+    has_issues = len(flow_info["issues"]) > 0
+    if has_issues == flow.has_issues:
+        return False
+
+    if stdout:
+        action = "Would update" if dry_run else "Updated"
+        stdout.write(f" {action}: {flow.uuid} {flow.name} (has_issues {flow.has_issues} -> {has_issues})")
+
+    if not dry_run:
+        flow.has_issues = has_issues
+        flow.save(update_fields=("has_issues",))
+
+    return True
+
+
+def _write_progress(stdout, num_inspected, num_updated, num_failed):
+    if num_inspected % 100 == 0:  # pragma: no cover
+        stdout.write(f" > Flows inspected: {num_inspected}, updated: {num_updated}, failed: {num_failed}")
+
+
+def _write_summary(stdout, num_inspected, num_updated, num_failed):
+    summary = f"Total flows inspected: {num_inspected}, updated: {num_updated}, failed: {num_failed}"
+    if stdout:
+        stdout.write(summary)
+    else:
+        print(summary)
+
+
+def inspect_flows(*, org=None, flow_uuid=None, dry_run=False, stdout=None):
+    if org and flow_uuid:
+        raise CommandError("Specify only one of --org or --flow")
+
     client = mailroom.get_client()
-
     num_inspected = 0
     num_updated = 0
-    num_invalid = 0
+    num_failed = 0
 
-    for flow in Flow.objects.filter(is_active=True).order_by("id"):
+    for flow in get_flow_queryset(org=org, flow_uuid=flow_uuid):
+        num_inspected += 1
+
         try:
-            flow_info = client.flow_inspect(flow.org_id, flow.get_definition())
-        except FlowValidationException:
-            num_invalid += 1
+            flow_info = _inspect_flow(client, flow)
+        except Exception as exc:
+            num_failed += 1
+            _report_inspection_error(flow, stdout, exc)
             continue
-        finally:
-            num_inspected += 1
 
-        has_issues = len(flow_info["issues"]) > 0
-
-        if has_issues != flow.has_issues:
-            flow.has_issues = has_issues
-            flow.save(update_fields=("has_issues",))
+        if _sync_has_issues(flow, flow_info, dry_run, stdout):
             num_updated += 1
 
-        if num_inspected % 100 == 0:  # pragma: no cover
-            print(f" > Flows inspected: {num_inspected}, updated: {num_updated}, invalid: {num_invalid}")
+        if stdout:
+            _write_progress(stdout, num_inspected, num_updated, num_failed)
 
-    print(f"Total flows inspected: {num_inspected}, updated: {num_updated}, invalid: {num_invalid}")
+    _write_summary(stdout, num_inspected, num_updated, num_failed)
+    return num_inspected, num_updated, num_failed
 
 
 class Command(BaseCommand):
-    help = "Inspects all flows for issues"
+    help = "Inspects flows and fixes has_issues where needed"
+
+    def add_arguments(self, parser):
+        parser.add_argument(
+            "--org",
+            dest="org",
+            help="Org id, org uuid, or project uuid to limit inspection to a single workspace",
+        )
+        parser.add_argument(
+            "--flow",
+            dest="flow_uuid",
+            help="Flow UUID to inspect a single flow",
+        )
+        parser.add_argument(
+            "--dry-run",
+            action="store_true",
+            dest="dry_run",
+            help="Report changes without saving has_issues",
+        )
 
     def handle(self, *args, **options):
-        inspect_flows()
+        org = None
+        if options["org"]:
+            org = resolve_org(options["org"])
+
+        inspect_flows(
+            org=org,
+            flow_uuid=options["flow_uuid"],
+            dry_run=options["dry_run"],
+            stdout=self.stdout,
+        )

--- a/temba/flows/management/commands/tests.py
+++ b/temba/flows/management/commands/tests.py
@@ -1,4 +1,7 @@
+from uuid import uuid4
+
 from django.core.management import call_command
+from django.db import connection
 from django.utils import timezone
 
 from temba.contacts.models import Contact
@@ -71,6 +74,76 @@ class InspectFlowsTest(TembaTest):
 
         flow3.refresh_from_db()
         self.assertFalse(flow3.has_issues)
+
+    def test_command_filters_by_org(self):
+        flow1 = self.create_flow("Org1 Flow", org=self.org)
+        flow1.has_issues = True
+        flow1.save(update_fields=("has_issues",))
+
+        flow2 = self.create_flow("Org2 Flow", org=self.org2)
+        flow2.has_issues = True
+        flow2.save(update_fields=("has_issues",))
+
+        call_command("inspect_flows", org=str(self.org.id))
+
+        flow1.refresh_from_db()
+        flow2.refresh_from_db()
+        self.assertFalse(flow1.has_issues)
+        self.assertTrue(flow2.has_issues)
+
+    def test_command_filters_by_proj_uuid(self):
+        self.org.proj_uuid = uuid4()
+        self.org.save(update_fields=("proj_uuid",))
+
+        flow1 = self.create_flow("Org1 Flow", org=self.org)
+        flow1.has_issues = True
+        flow1.save(update_fields=("has_issues",))
+
+        call_command("inspect_flows", org=str(self.org.proj_uuid))
+
+        flow1.refresh_from_db()
+        self.assertFalse(flow1.has_issues)
+
+    def test_command_filters_by_flow_uuid(self):
+        flow1 = self.create_flow("No Problems")
+        flow1.has_issues = True
+        flow1.save(update_fields=("has_issues",))
+
+        flow2 = self.create_flow("Also No Problems")
+        flow2.has_issues = True
+        flow2.save(update_fields=("has_issues",))
+
+        call_command("inspect_flows", flow=str(flow1.uuid))
+
+        flow1.refresh_from_db()
+        flow2.refresh_from_db()
+        self.assertFalse(flow1.has_issues)
+        self.assertTrue(flow2.has_issues)
+
+    def test_command_dry_run(self):
+        flow1 = self.create_flow("No Problems")
+        flow1.has_issues = True
+        flow1.save(update_fields=("has_issues",))
+
+        call_command("inspect_flows", flow=str(flow1.uuid), dry_run=True)
+
+        flow1.refresh_from_db()
+        self.assertTrue(flow1.has_issues)
+
+    def test_command_handles_unreadable_flow(self):
+        flow1 = self.create_flow("No Problems")
+        flow1.has_issues = True
+        flow1.save(update_fields=("has_issues",))
+
+        flow2 = self.create_flow("Unreadable")
+        revision_id = flow2.revisions.order_by("revision").last().id
+        with connection.cursor() as cursor:
+            cursor.execute("UPDATE flows_flowrevision SET definition = %s WHERE id = %s", ["", revision_id])
+
+        call_command("inspect_flows")
+
+        flow1.refresh_from_db()
+        self.assertFalse(flow1.has_issues)
 
 
 class RecalcNodeCountsTest(TembaTest):


### PR DESCRIPTION
## Summary

Improves the `inspect_flows` management command to reconcile stale `Flow.has_issues` flags. Adds scoped execution (by org or flow), a dry-run mode, and resilient error handling so a single unreadable flow no longer aborts the entire run.

## Problem

Some flows show a warning icon in the flow list even though no issues appear when opening them in the editor. This happens because:

- The list view uses the persisted `Flow.has_issues` flag.
- The editor performs a live inspection via mailroom on each open.
- `has_issues` can be set to `True` optimistically (e.g. when a soft dependency is released) without being reconciled later.
- There is no periodic reconciliation job in `CELERY_BEAT_SCHEDULE`.

The existing `inspect_flows` command could fix this, but it had limitations:

- Inspected all active flows across the entire instance.
- Aborted on the first unreadable flow (e.g. corrupted revision JSON).
- Offered no dry-run or scoped execution for support use cases.

## Changes

- Add `--org` to limit inspection to a single workspace (accepts org id, org uuid, or `proj_uuid`).
- Add `--flow` to inspect a single flow by UUID (includes inactive flows).
- Add `--dry-run` to report mismatches without saving.
- Skip and report flows that fail inspection (`Invalid` / `Unreadable`) instead of aborting the command.
- Refactor command logic into smaller helpers to reduce cognitive complexity.
- Expand test coverage for org/proj_uuid/flow filtering, dry-run, and unreadable flows.

## Usage

```bash
# All active flows (existing behavior)
python manage.py inspect_flows

# Single project/workspace
python manage.py inspect_flows --org <proj_uuid>

# Single flow
python manage.py inspect_flows --flow <flow_uuid>

# Preview changes only
python manage.py inspect_flows --org <proj_uuid> --dry-run