### PR TITLE
fix: Sanitize unpaired Unicode surrogates in WhatsApp Flow assets

### DIFF
--- a/WENI-CHANGELOG.md
+++ b/WENI-CHANGELOG.md
@@ -1,3 +1,7 @@
+3.90.1
+----------
+* fix: sanitize unpaired Unicode surrogates in WhatsApp Flow assets sync
+
 3.90.0
 ----------
 * feat: add whatsapp bsuid urn validation

--- a/temba/wpp_flows/tasks.py
+++ b/temba/wpp_flows/tasks.py
@@ -4,6 +4,7 @@ import requests
 from django_redis import get_redis_connection
 
 from django.conf import settings
+from django.db import DatabaseError
 from django.utils import timezone
 
 from celery import shared_task
@@ -13,6 +14,20 @@ from temba.request_logs.models import HTTPLog
 from temba.wpp_flows.models import WhatsappFlow
 
 logger = logging.getLogger(__name__)
+
+# Unpaired UTF-16 surrogates are valid in Python strings but rejected by PostgreSQL's JSON type.
+_SURROGATE_REPLACEMENT = "\ufffd"
+
+
+def _sanitize_json_for_postgres(value):
+    """Replace unpaired Unicode surrogates so the value can be stored in a JSONField."""
+    if isinstance(value, str):
+        return "".join(ch if not (0xD800 <= ord(ch) <= 0xDFFF) else _SURROGATE_REPLACEMENT for ch in value)
+    if isinstance(value, list):
+        return [_sanitize_json_for_postgres(item) for item in value]
+    if isinstance(value, dict):
+        return {_sanitize_json_for_postgres(key): _sanitize_json_for_postgres(item) for key, item in value.items()}
+    return value
 
 
 @shared_task(track_started=True, name="refresh_whatsapp_flows")
@@ -85,35 +100,41 @@ def update_whatsapp_flows(flows, channel):
     seen = []
 
     for obj in flows:
-        flow = WhatsappFlow.objects.filter(facebook_flow_id=obj.get("id"), channel=channel).first()
-        assets_data = get_assets_data(channel, obj.get("id"))
-        variables = extract_data_keys(assets_data)
+        facebook_flow_id = obj.get("id")
+        # Always mark as seen so a save failure does not deactivate a flow that still exists on Meta.
+        seen.append(facebook_flow_id)
+        try:
+            flow = WhatsappFlow.objects.filter(facebook_flow_id=facebook_flow_id, channel=channel).first()
+            assets_data = get_assets_data(channel, facebook_flow_id)
+            variables = extract_data_keys(assets_data)
 
-        if flow:
-            flow.category = obj.get("categories")
-            flow.status = obj.get("status")
-            flow.name = obj.get("name")
-            flow.validation_errors = obj.get("validation_errors")
-            flow.screens = assets_data
-            flow.variables = variables
-            flow.modified_on = timezone.now()
-            flow.save()
-
-        else:
-            WhatsappFlow.objects.create(
-                facebook_flow_id=obj.get("id"),
-                category=obj.get("categories"),
-                status=obj.get("status"),
-                name=obj.get("name"),
-                validation_errors=obj.get("validation_errors"),
-                screens=assets_data,
-                variables=variables,
-                org=channel.org,
-                channel=channel,
-                is_active=True,
+            if flow:
+                flow.category = obj.get("categories")
+                flow.status = obj.get("status")
+                flow.name = obj.get("name")
+                flow.validation_errors = obj.get("validation_errors")
+                flow.screens = assets_data
+                flow.variables = variables
+                flow.modified_on = timezone.now()
+                flow.save()
+            else:
+                WhatsappFlow.objects.create(
+                    facebook_flow_id=facebook_flow_id,
+                    category=obj.get("categories"),
+                    status=obj.get("status"),
+                    name=obj.get("name"),
+                    validation_errors=obj.get("validation_errors"),
+                    screens=assets_data,
+                    variables=variables,
+                    org=channel.org,
+                    channel=channel,
+                    is_active=True,
+                )
+        except DatabaseError:
+            logger.exception(
+                "failed to sync whatsapp flow",
+                extra={"facebook_flow_id": facebook_flow_id, "channel_id": channel.id},
             )
-
-        seen.append(obj.get("id"))
 
     WhatsappFlow.trim(channel, seen)
 
@@ -132,10 +153,16 @@ def get_assets_data(channel, facebook_flow_id):
                 download_url = assets_info[0]["download_url"]
                 # get JSON of download_url
                 json_data = requests.get(download_url).json()
-                return json_data
+                return _sanitize_json_for_postgres(json_data)
     except requests.RequestException as e:
         start = timezone.now()
         HTTPLog.create_from_exception(HTTPLog.WHATSAPP_FLOWS_SYNCED, url, e, start, channel=channel)
+    except ValueError:
+        # Covers JSONDecodeError from resp.json() / download payload parse failures.
+        logger.exception(
+            "failed to parse whatsapp flow assets",
+            extra={"facebook_flow_id": facebook_flow_id, "channel_id": channel.id},
+        )
 
     return {}
 
@@ -231,14 +258,21 @@ def refresh_whatsapp_flows_assets_for_a_flow(facebook_flow_id):
 
 
 def _update_assets(flow):
-    channel = flow.channel
+    try:
+        channel = flow.channel
 
-    assets_data = get_assets_data(channel, flow.facebook_flow_id)
-    variables = extract_data_keys(assets_data)
+        assets_data = get_assets_data(channel, flow.facebook_flow_id)
+        variables = extract_data_keys(assets_data)
 
-    flow.screens = assets_data
-    flow.variables = variables
-    flow.modified_on = timezone.now()
-    flow.save()
+        flow.screens = assets_data
+        flow.variables = variables
+        flow.modified_on = timezone.now()
+        flow.save()
+    except DatabaseError:
+        logger.exception(
+            "failed to sync whatsapp flow assets",
+            extra={"facebook_flow_id": flow.facebook_flow_id, "flow_id": flow.id},
+        )
+        return None
 
     return flow

--- a/temba/wpp_flows/tests/tests_models.py
+++ b/temba/wpp_flows/tests/tests_models.py
@@ -4,10 +4,13 @@ from unittest.mock import Mock, patch
 import requests
 
 from django.conf import settings
+from django.db import DatabaseError
 from django.utils import timezone
 
 from temba.wpp_flows.tasks import (
     _get_token,
+    _sanitize_json_for_postgres,
+    _update_assets,
     extract_data_keys,
     get_assets_data,
     get_whatsapp_flows,
@@ -23,7 +26,11 @@ class RefreshWhatsappFlowsTest(unittest.TestCase):
     @patch("temba.wpp_flows.tasks.get_whatsapp_flows")
     @patch("temba.wpp_flows.tasks.update_whatsapp_flows")
     def test_refresh_whatsapp_flows(
-        self, mock_update_whatsapp_flows, mock_get_whatsapp_flows, mock_channel_filter, mock_get_redis_connection
+        self,
+        mock_update_whatsapp_flows,
+        mock_get_whatsapp_flows,
+        mock_channel_filter,
+        mock_get_redis_connection,
     ):
         mock_redis = Mock()
         mock_get_redis_connection.return_value = mock_redis
@@ -54,7 +61,11 @@ class RefreshWhatsappFlowsTest(unittest.TestCase):
     @patch("temba.wpp_flows.tasks.HTTPLog.create_from_exception")
     @patch("temba.wpp_flows.tasks._get_token")
     def test_get_whatsapp_flows(
-        self, mock_get_token, mock_create_from_exception, mock_create_from_response, mock_requests_get
+        self,
+        mock_get_token,
+        mock_create_from_exception,
+        mock_create_from_response,
+        mock_requests_get,
     ):
         mock_channel = Mock()
         mock_channel.config.get.return_value = "test_waba_id"
@@ -82,16 +93,25 @@ class RefreshWhatsappFlowsTest(unittest.TestCase):
         self.assertEqual(result, [])
         mock_create_from_exception.assert_called_once()
 
+    @patch("temba.wpp_flows.tasks.WhatsappFlow.trim")
+    @patch("temba.wpp_flows.tasks.get_assets_data")
     @patch("temba.wpp_flows.tasks.timezone.now")
     @patch("temba.wpp_flows.tasks.WhatsappFlow.objects.filter")
-    def test_update_whatsapp_flows(self, mock_filter, mock_timezone_now):
+    def test_update_whatsapp_flows(self, mock_filter, mock_timezone_now, mock_get_assets, mock_trim):
         mock_channel = Mock()
         mock_channel.org = Mock()
         mock_flow = Mock()
         mock_timezone_now.return_value = timezone.now()
+        mock_get_assets.return_value = {}
 
         flows = [
-            {"id": "flow1", "categories": ["cat1"], "status": "active", "name": "Flow 1", "validation_errors": []}
+            {
+                "id": "flow1",
+                "categories": ["cat1"],
+                "status": "active",
+                "name": "Flow 1",
+                "validation_errors": [],
+            }
         ]
 
         mock_query = Mock()
@@ -105,6 +125,7 @@ class RefreshWhatsappFlowsTest(unittest.TestCase):
         self.assertEqual(mock_flow.name, "Flow 1")
         self.assertEqual(mock_flow.validation_errors, [])
         self.assertEqual(mock_flow.modified_on, mock_timezone_now.return_value)
+        mock_trim.assert_called_once_with(mock_channel, ["flow1"])
 
         mock_query.first.return_value = None
         with patch("temba.wpp_flows.tasks.WhatsappFlow.objects.create") as mock_create:
@@ -122,6 +143,46 @@ class RefreshWhatsappFlowsTest(unittest.TestCase):
                 is_active=True,
             )
 
+    @patch("temba.wpp_flows.tasks.WhatsappFlow.trim")
+    @patch("temba.wpp_flows.tasks.get_assets_data")
+    @patch("temba.wpp_flows.tasks.WhatsappFlow.objects.filter")
+    def test_update_whatsapp_flows_continues_on_save_error(self, mock_filter, mock_get_assets, mock_trim):
+        mock_channel = Mock()
+        mock_channel.id = 1
+        mock_channel.org = Mock()
+        mock_get_assets.return_value = {}
+
+        failing_flow = Mock()
+        failing_flow.save.side_effect = DatabaseError("db error")
+
+        ok_flow = Mock()
+
+        flows = [
+            {
+                "id": "flow1",
+                "categories": ["cat1"],
+                "status": "active",
+                "name": "Flow 1",
+                "validation_errors": [],
+            },
+            {
+                "id": "flow2",
+                "categories": ["cat2"],
+                "status": "active",
+                "name": "Flow 2",
+                "validation_errors": [],
+            },
+        ]
+
+        mock_query = Mock()
+        mock_query.first.side_effect = [failing_flow, ok_flow]
+        mock_filter.return_value = mock_query
+
+        update_whatsapp_flows(flows, mock_channel)
+
+        ok_flow.save.assert_called_once()
+        mock_trim.assert_called_once_with(mock_channel, ["flow1", "flow2"])
+
     @patch("temba.wpp_flows.tasks.settings.WHATSAPP_ADMIN_SYSTEM_USER_TOKEN", "admin_token")
     def test_get_token(self):
         mock_channel = Mock()
@@ -137,6 +198,55 @@ class RefreshWhatsappFlowsTest(unittest.TestCase):
         self.assertEqual(token, "admin_token")
 
 
+class SanitizeJsonForPostgresTest(unittest.TestCase):
+    def test_replaces_unpaired_surrogates_in_strings(self):
+        # High surrogate without a following low surrogate (same class of bad data seen in Sentry).
+        dirty = "^(?!.*[\ud83c-])"
+        result = _sanitize_json_for_postgres(dirty)
+        self.assertNotIn("\ud83c", result)
+        self.assertIn("\ufffd", result)
+
+    def test_sanitizes_nested_structures(self):
+        payload = {
+            "screens": [
+                {
+                    "id": "INICIO",
+                    "layout": {
+                        "type": "SingleColumnLayout",
+                        "children": [{"type": "TextInput", "pattern": "^(?!.*[\ud83c-\ud83d])"}],
+                    },
+                }
+            ]
+        }
+
+        result = _sanitize_json_for_postgres(payload)
+        pattern = result["screens"][0]["layout"]["children"][0]["pattern"]
+        self.assertNotIn("\ud83c", pattern)
+        self.assertNotIn("\ud83d", pattern)
+        self.assertEqual(result["screens"][0]["id"], "INICIO")
+
+    def test_leaves_valid_values_unchanged(self):
+        payload = {
+            "screens": [{"id": "A", "data": {"name": "ok"}}],
+            "count": 1,
+            "active": True,
+            "empty": None,
+        }
+        self.assertEqual(_sanitize_json_for_postgres(payload), payload)
+
+    def test_sanitizes_dictionary_keys(self):
+        dirty_key = "field_\ud83c"
+        payload = {dirty_key: "value"}
+
+        result = _sanitize_json_for_postgres(payload)
+
+        self.assertEqual(len(result), 1)
+        sanitized_key = next(iter(result))
+        self.assertNotIn("\ud83c", sanitized_key)
+        self.assertIn("\ufffd", sanitized_key)
+        self.assertEqual(result[sanitized_key], "value")
+
+
 class GetAssetsDataTest(unittest.TestCase):
     @patch("temba.wpp_flows.tasks.requests.get")
     @patch("temba.wpp_flows.tasks._get_token")
@@ -149,15 +259,41 @@ class GetAssetsDataTest(unittest.TestCase):
         mock_resp = Mock()
         mock_resp.status_code = 200
         mock_resp.json.return_value = {"data": [{"download_url": "https://example.com/download"}]}
-        mock_requests_get.side_effect = [mock_resp, Mock(status_code=200, json=Mock(return_value={"key": "value"}))]
+        mock_requests_get.side_effect = [
+            mock_resp,
+            Mock(status_code=200, json=Mock(return_value={"key": "value"})),
+        ]
 
         result = get_assets_data(mock_channel, facebook_flow_id)
 
         self.assertEqual(result, {"key": "value"})
         mock_get_token.assert_called_once_with(mock_channel)
         mock_requests_get.assert_any_call(
-            f"{settings.WHATSAPP_API_URL}/{facebook_flow_id}/assets", headers={"Authorization": "Bearer test_token"}
+            f"{settings.WHATSAPP_API_URL}/{facebook_flow_id}/assets",
+            headers={"Authorization": "Bearer test_token"},
         )
+        mock_create_from_exception.assert_not_called()
+
+    @patch("temba.wpp_flows.tasks.requests.get")
+    @patch("temba.wpp_flows.tasks._get_token")
+    @patch("temba.wpp_flows.tasks.HTTPLog.create_from_exception")
+    def test_get_assets_data_sanitizes_surrogates(self, mock_create_from_exception, mock_get_token, mock_requests_get):
+        mock_channel = Mock()
+        mock_get_token.return_value = "test_token"
+
+        dirty_payload = {"pattern": "^(?!.*[\ud83c-])"}
+        mock_resp = Mock()
+        mock_resp.status_code = 200
+        mock_resp.json.return_value = {"data": [{"download_url": "https://example.com/download"}]}
+        mock_requests_get.side_effect = [
+            mock_resp,
+            Mock(status_code=200, json=Mock(return_value=dirty_payload)),
+        ]
+
+        result = get_assets_data(mock_channel, "flow_id")
+
+        self.assertNotIn("\ud83c", result["pattern"])
+        self.assertIn("\ufffd", result["pattern"])
         mock_create_from_exception.assert_not_called()
 
     @patch("temba.wpp_flows.tasks.requests.get")
@@ -175,9 +311,28 @@ class GetAssetsDataTest(unittest.TestCase):
         self.assertEqual(result, {})
         mock_get_token.assert_called_once_with(mock_channel)
         mock_requests_get.assert_called_once_with(
-            f"{settings.WHATSAPP_API_URL}/{facebook_flow_id}/assets", headers={"Authorization": "Bearer test_token"}
+            f"{settings.WHATSAPP_API_URL}/{facebook_flow_id}/assets",
+            headers={"Authorization": "Bearer test_token"},
         )
         mock_create_from_exception.assert_called_once()
+
+    @patch("temba.wpp_flows.tasks.requests.get")
+    @patch("temba.wpp_flows.tasks._get_token")
+    @patch("temba.wpp_flows.tasks.HTTPLog.create_from_exception")
+    def test_get_assets_data_invalid_json(self, mock_create_from_exception, mock_get_token, mock_requests_get):
+        mock_channel = Mock()
+        mock_channel.id = 1
+        mock_get_token.return_value = "test_token"
+
+        mock_resp = Mock()
+        mock_resp.status_code = 200
+        mock_resp.json.side_effect = ValueError("Invalid JSON")
+        mock_requests_get.return_value = mock_resp
+
+        result = get_assets_data(mock_channel, "flow_id")
+
+        self.assertEqual(result, {})
+        mock_create_from_exception.assert_not_called()
 
     @patch("temba.wpp_flows.tasks.requests.get")
     @patch("temba.wpp_flows.tasks._get_token")
@@ -196,8 +351,54 @@ class GetAssetsDataTest(unittest.TestCase):
         self.assertEqual(result, {})
         mock_get_token.assert_called_once_with(mock_channel)
         mock_requests_get.assert_called_once_with(
-            f"{settings.WHATSAPP_API_URL}/{facebook_flow_id}/assets", headers={"Authorization": "Bearer test_token"}
+            f"{settings.WHATSAPP_API_URL}/{facebook_flow_id}/assets",
+            headers={"Authorization": "Bearer test_token"},
         )
+
+
+class UpdateAssetsTest(unittest.TestCase):
+    @patch("temba.wpp_flows.tasks.extract_data_keys")
+    @patch("temba.wpp_flows.tasks.get_assets_data")
+    def test_update_assets_success(self, mock_get_assets, mock_extract):
+        mock_get_assets.return_value = {"screens": []}
+        mock_extract.return_value = {"screens": [], "variables": []}
+        flow = Mock()
+        flow.channel = Mock()
+        flow.facebook_flow_id = "fb-1"
+
+        result = _update_assets(flow)
+
+        flow.save.assert_called_once()
+        self.assertEqual(result, flow)
+
+    @patch("temba.wpp_flows.tasks.extract_data_keys")
+    @patch("temba.wpp_flows.tasks.get_assets_data")
+    def test_update_assets_swallows_save_error(self, mock_get_assets, mock_extract):
+        mock_get_assets.return_value = {"screens": []}
+        mock_extract.return_value = {"screens": [], "variables": []}
+        flow = Mock()
+        flow.id = 10
+        flow.facebook_flow_id = "fb-1"
+        flow.channel = Mock()
+        flow.save.side_effect = DatabaseError("invalid json")
+
+        result = _update_assets(flow)
+
+        self.assertIsNone(result)
+
+    @patch("temba.wpp_flows.tasks.extract_data_keys")
+    @patch("temba.wpp_flows.tasks.get_assets_data")
+    def test_update_assets_reraises_non_database_error(self, mock_get_assets, mock_extract):
+        mock_get_assets.return_value = {"screens": []}
+        mock_extract.return_value = {"screens": [], "variables": []}
+        flow = Mock()
+        flow.id = 10
+        flow.facebook_flow_id = "fb-1"
+        flow.channel = Mock()
+        flow.save.side_effect = AttributeError("bug")
+
+        with self.assertRaises(AttributeError):
+            _update_assets(flow)
 
 
 class ExtractDataKeysTest(unittest.TestCase):
@@ -208,7 +409,10 @@ class ExtractDataKeysTest(unittest.TestCase):
         self.assertCountEqual(result, {"screens": ["screen_1"], "variables": ["var1", "var2"]})
 
     def test_extract_data_keys_with_list(self):
-        json_data = [{"id": "screen_1", "data": {"var1": "value1"}}, {"id": "screen_2", "data": {"var2": "value2"}}]
+        json_data = [
+            {"id": "screen_1", "data": {"var1": "value1"}},
+            {"id": "screen_2", "data": {"var2": "value2"}},
+        ]
 
         result = extract_data_keys(json_data)
         self.assertCountEqual(result, {"screens": ["screen_2", "screen_1"], "variables": ["var1", "var2"]})


### PR DESCRIPTION
## What

Sanitize unpaired UTF-16 surrogates in WhatsApp Flow asset JSON before
persisting to PostgreSQL JSONField, and isolate sync failures per flow so
one bad payload does not abort the batch.

## Why

Flows with incomplete emoji surrogate escapes in regex patterns caused
DataError on save (FLOWS-22Z, FLOWS-25X, FLOWS-230), repeatedly failing
refresh_whatsapp_flows and refresh_whatsapp_flows_assets.

Fixes FLOWS-22Z
Fixes FLOWS-25X
Fixes FLOWS-230