### PR TITLE
feat: make Sentry sampling and ignored errors configurable via env

### DIFF
--- a/WENI-CHANGELOG.md
+++ b/WENI-CHANGELOG.md
@@ -1,3 +1,7 @@
+Unreleased
+----------
+* feat: make Sentry sample rates and ignored errors configurable via environment variables (CLOUDW-4325)
+
 3.89.0
 ----------
 * fix: Migrate project consumer to AmazonMQ

--- a/temba/sentry_config.py
+++ b/temba/sentry_config.py
@@ -1,0 +1,48 @@
+import builtins
+import os
+
+try:
+    from redis.exceptions import LockNotOwnedError
+except ImportError:  # pragma: no cover
+    LockNotOwnedError = None
+
+# Project/third-party exceptions that can be referenced by name in SENTRY_IGNORE_ERRORS
+CUSTOM_EXCEPTIONS = {}
+if LockNotOwnedError is not None:
+    CUSTOM_EXCEPTIONS["LockNotOwnedError"] = LockNotOwnedError
+
+
+def get_float_env(var_name: str, default: float) -> float:
+    """Read an environment variable and convert it to float safely."""
+    value = os.getenv(var_name)
+    if value is None or value == "":
+        return default
+    try:
+        return float(value)
+    except ValueError:
+        return default
+
+
+def get_ignored_errors_from_env(env_var: str = "SENTRY_IGNORE_ERRORS"):
+    """
+    Resolve exception classes from a comma-separated env var.
+
+    Supports builtin exceptions (e.g. ValueError) and names registered in
+    CUSTOM_EXCEPTIONS (e.g. LockNotOwnedError).
+    """
+    raw_env = os.getenv(env_var, "")
+    if not raw_env:
+        return []
+
+    ignored_classes = []
+    error_names = [name.strip() for name in raw_env.split(",") if name.strip()]
+
+    for name in error_names:
+        err_cls = getattr(builtins, name, None)
+        if err_cls is None:
+            err_cls = CUSTOM_EXCEPTIONS.get(name)
+
+        if err_cls and isinstance(err_cls, type) and issubclass(err_cls, BaseException):
+            ignored_classes.append(err_cls)
+
+    return ignored_classes

--- a/temba/settings_common.py
+++ b/temba/settings_common.py
@@ -15,6 +15,8 @@ from django.utils.translation import ugettext_lazy as _
 
 from celery.schedules import crontab
 
+from .sentry_config import get_float_env, get_ignored_errors_from_env
+
 SENTRY_DSN = os.environ.get("SENTRY_DSN", "")
 
 
@@ -23,7 +25,13 @@ if SENTRY_DSN:  # pragma: no cover
         dsn=SENTRY_DSN,
         integrations=[DjangoIntegration(), CeleryIntegration(), LoggingIntegration()],
         send_default_pii=True,
-        traces_sample_rate=0,
+        ignore_errors=get_ignored_errors_from_env(),
+        # Fraction of error events to send (1.0 = 100%). Override with SENTRY_SAMPLE_RATE.
+        sample_rate=get_float_env("SENTRY_SAMPLE_RATE", 1.0),
+        # Performance transactions. Default keeps previous behavior (disabled).
+        traces_sample_rate=get_float_env("SENTRY_TRACES_SAMPLE_RATE", 0.0),
+        # Profiling. Default disabled.
+        profiles_sample_rate=get_float_env("SENTRY_PROFILES_SAMPLE_RATE", 0.0),
     )
     ignore_logger("django.security.DisallowedHost")
 

--- a/temba/tests/test_sentry_config.py
+++ b/temba/tests/test_sentry_config.py
@@ -1,0 +1,47 @@
+import os
+from unittest import TestCase, mock
+
+from redis.exceptions import LockNotOwnedError
+
+from temba.sentry_config import get_float_env, get_ignored_errors_from_env
+
+
+class GetFloatEnvTest(TestCase):
+    def test_returns_default_when_missing(self):
+        with mock.patch.dict(os.environ, {}, clear=True):
+            self.assertEqual(get_float_env("SENTRY_SAMPLE_RATE", 1.0), 1.0)
+
+    def test_returns_default_when_empty(self):
+        with mock.patch.dict(os.environ, {"SENTRY_SAMPLE_RATE": ""}, clear=False):
+            self.assertEqual(get_float_env("SENTRY_SAMPLE_RATE", 0.5), 0.5)
+
+    def test_parses_valid_float(self):
+        with mock.patch.dict(os.environ, {"SENTRY_TRACES_SAMPLE_RATE": "0.1"}):
+            self.assertEqual(get_float_env("SENTRY_TRACES_SAMPLE_RATE", 1.0), 0.1)
+
+    def test_returns_default_on_invalid_value(self):
+        with mock.patch.dict(os.environ, {"SENTRY_PROFILES_SAMPLE_RATE": "abc"}):
+            self.assertEqual(get_float_env("SENTRY_PROFILES_SAMPLE_RATE", 0.0), 0.0)
+
+
+class GetIgnoredErrorsFromEnvTest(TestCase):
+    def test_returns_empty_when_unset(self):
+        with mock.patch.dict(os.environ, {}, clear=True):
+            os.environ.pop("SENTRY_IGNORE_ERRORS", None)
+            self.assertEqual(get_ignored_errors_from_env(), [])
+
+    def test_resolves_builtin_exceptions(self):
+        with mock.patch.dict(os.environ, {"SENTRY_IGNORE_ERRORS": "ValueError, KeyError"}):
+            self.assertEqual(get_ignored_errors_from_env(), [ValueError, KeyError])
+
+    def test_resolves_custom_exceptions(self):
+        with mock.patch.dict(os.environ, {"SENTRY_IGNORE_ERRORS": "LockNotOwnedError"}):
+            self.assertEqual(get_ignored_errors_from_env(), [LockNotOwnedError])
+
+    def test_skips_unknown_names(self):
+        with mock.patch.dict(os.environ, {"SENTRY_IGNORE_ERRORS": "ValueError,NotARealError"}):
+            self.assertEqual(get_ignored_errors_from_env(), [ValueError])
+
+    def test_ignores_non_exception_builtins(self):
+        with mock.patch.dict(os.environ, {"SENTRY_IGNORE_ERRORS": "int,ValueError"}):
+            self.assertEqual(get_ignored_errors_from_env(), [ValueError])


### PR DESCRIPTION
## Summary
- Makes Sentry `sample_rate`, `traces_sample_rate`, `profiles_sample_rate` and `ignore_errors` configurable via environment variables
- Adds helpers in `temba/sentry_config.py` to safely parse floats and resolve exception classes from `SENTRY_IGNORE_ERRORS`
- PoC for CLOUDW-4325 to reduce Sentry overload from noisy/known errors in flows

## Related
- Jira: [CLOUDW-4325](https://vtex-dev.atlassian.net/browse/CLOUDW-4325)

## New environment variables
| Variable | Default | Description |
|---|---|---|
| `SENTRY_IGNORE_ERRORS` | _(empty)_ | Comma-separated exception class names to ignore (builtins + custom map, e.g. `LockNotOwnedError`) |
| `SENTRY_SAMPLE_RATE` | `1.0` | Fraction of error events to send |
| `SENTRY_TRACES_SAMPLE_RATE` | `0.0` | Performance transactions sample rate (keeps previous behavior) |
| `SENTRY_PROFILES_SAMPLE_RATE` | `0.0` | Profiling sample rate |

## Test plan
- [ ] Unit tests for `temba.sentry_config` pass
- [ ] With `SENTRY_DSN` set and no ignore list, a raised exception still appears in Sentry
- [ ] With `SENTRY_IGNORE_ERRORS=ValueError`, a `ValueError` is not sent to Sentry
- [ ] With `SENTRY_SAMPLE_RATE=0`, error events are not sent
- [ ] Defaults preserve previous behavior (`traces_sample_rate=0`, all errors sampled)
- [ ] Configmap/env updated in staging before enabling ignore list in production
