### PR TITLE
feat: search contacts on WhatsApp URNs before tel fallback

### DIFF
--- a/temba/contacts/search/__init__.py
+++ b/temba/contacts/search/__init__.py
@@ -1,7 +1,1 @@
 from .mailroom import ParsedQuery, SearchException, SearchResults, parse_query, search_contacts  # noqa
-from .phone_search import (  # noqa: F401
-    ContactSearchOutcome,
-    build_phone_urn_query,
-    is_bare_phone_search,
-    search_contacts_resolving_phone,
-)

--- a/temba/contacts/search/__init__.py
+++ b/temba/contacts/search/__init__.py
@@ -1,1 +1,7 @@
 from .mailroom import ParsedQuery, SearchException, SearchResults, parse_query, search_contacts  # noqa
+from .phone_search import (  # noqa: F401
+    ContactSearchOutcome,
+    build_phone_urn_query,
+    is_bare_phone_search,
+    search_contacts_resolving_phone,
+)

--- a/temba/contacts/search/omnibox.py
+++ b/temba/contacts/search/omnibox.py
@@ -11,6 +11,7 @@ from temba.msgs.models import Label
 from temba.utils.models import IDSliceQuerySet
 
 from . import SearchException, search_contacts
+from .phone_search import search_contacts_resolving_phone
 
 SEARCH_ALL_GROUPS = "g"
 SEARCH_STATIC_GROUPS = "s"
@@ -100,7 +101,9 @@ def omnibox_mixed_search(org, query, types):
     if SEARCH_CONTACTS in search_types:
         try:
             # query elastic search for contact ids, then fetch contacts from db
-            search_results = search_contacts(org, query, group=org.active_contacts_group, sort="name")
+            search_results = search_contacts_resolving_phone(
+                org, query, group=org.active_contacts_group, sort="name"
+            ).results
             contacts = IDSliceQuerySet(
                 Contact,
                 search_results.contact_ids,

--- a/temba/contacts/search/phone_search.py
+++ b/temba/contacts/search/phone_search.py
@@ -7,10 +7,11 @@ from .mailroom import SearchResults, search_contacts
 
 WHATSAPP_SCHEME = "whatsapp"
 TEL_SCHEME = "tel"
+MIN_IMPLICIT_PHONE_DIGITS = 4
 
 _CONTACTQL_HINTS = re.compile(r"[~>=]|(?:^|\s)(?:and|or|not)\s", re.I)
 _SCHEME_HINTS = re.compile(r"(?:^|\s)(?:tel|whatsapp|twitter|email|facebook|instagram|telegram|discord)\s*[=~]", re.I)
-_IMPLICIT_PHONE = re.compile(r"^\+?[-\d]{4,}$")
+_IMPLICIT_PHONE = re.compile(rf"^\+?[-\d]{{{MIN_IMPLICIT_PHONE_DIGITS},}}$")
 
 
 class ContactSearchOutcome:
@@ -81,3 +82,13 @@ def search_contacts_resolving_phone(
     tel_query = build_phone_urn_query(TEL_SCHEME, query)
     tel_results = search_contacts(org, tel_query, **search_kwargs)
     return ContactSearchOutcome(tel_results, phone_fallback=True)
+
+
+def search_contacts_for_list(org, query, *, group=None, sort=None, offset=None, exclude_ids=()):
+    """
+    Runs contact list search and returns the mailroom results with phone fallback metadata.
+    """
+    outcome = search_contacts_resolving_phone(
+        org, query, group=group, sort=sort, offset=offset, exclude_ids=exclude_ids
+    )
+    return outcome.results, outcome.phone_fallback

--- a/temba/contacts/search/phone_search.py
+++ b/temba/contacts/search/phone_search.py
@@ -1,0 +1,76 @@
+import json
+import re
+
+from temba.contacts.models import URN
+from temba.utils.whatsapp.ninth_digit import get_number_search_terms
+
+from .mailroom import SearchResults, search_contacts
+
+_CONTACTQL_HINTS = re.compile(r"[~>=]|(?:^|\s)(?:and|or|not)\s", re.I)
+_SCHEME_HINTS = re.compile(r"(?:^|\s)(?:tel|whatsapp|twitter|email|facebook|instagram|telegram|discord)\s*[=~]", re.I)
+_IMPLICIT_PHONE = re.compile(r"^\+?[-\d]{4,}$")
+
+
+class ContactSearchOutcome:
+    __slots__ = ("results", "phone_fallback")
+
+    def __init__(self, results: SearchResults, phone_fallback: bool = False):
+        self.results = results
+        self.phone_fallback = phone_fallback
+
+
+def is_bare_phone_search(query: str, org) -> bool:
+    """
+    Returns whether the query is a bare phone number rather than a contactql expression.
+    """
+    query = (query or "").strip()
+    if not query or _SCHEME_HINTS.search(query) or _CONTACTQL_HINTS.search(query):
+        return False
+
+    if _IMPLICIT_PHONE.match(query):
+        return True
+
+    return URN.looks_like_phone(query, org.default_country_code)
+
+
+def build_phone_urn_query(scheme: str, raw_query: str) -> str:
+    """
+    Builds a contactql partial URN query for the given scheme and phone-like input.
+    """
+    terms = get_number_search_terms(raw_query)
+    digits = terms["literal"]
+    if not digits:
+        raise ValueError("phone search requires digits")
+
+    clauses = [f"{scheme} ~ {json.dumps(digits)}"]
+
+    if scheme == URN.WHATSAPP_SCHEME and terms["whatsapp_variant"]:
+        clauses.append(f"{scheme} ~ {json.dumps(terms['whatsapp_variant'])}")
+
+    if len(clauses) == 1:
+        return clauses[0]
+
+    return f"({' OR '.join(clauses)})"
+
+
+def search_contacts_resolving_phone(
+    org, query: str, *, group=None, sort: str = None, offset: int = None, exclude_ids=()
+) -> ContactSearchOutcome:
+    """
+    Runs contact search, resolving bare phone numbers on WhatsApp URNs first and tel URNs second.
+    """
+    if not is_bare_phone_search(query, org):
+        return ContactSearchOutcome(
+            search_contacts(org, query, group=group, sort=sort, offset=offset, exclude_ids=exclude_ids)
+        )
+
+    search_kwargs = dict(group=group, sort=sort, offset=offset, exclude_ids=exclude_ids)
+
+    whatsapp_query = build_phone_urn_query(URN.WHATSAPP_SCHEME, query)
+    whatsapp_results = search_contacts(org, whatsapp_query, **search_kwargs)
+    if whatsapp_results.total > 0:
+        return ContactSearchOutcome(whatsapp_results)
+
+    tel_query = build_phone_urn_query(URN.TEL_SCHEME, query)
+    tel_results = search_contacts(org, tel_query, **search_kwargs)
+    return ContactSearchOutcome(tel_results, phone_fallback=True)

--- a/temba/contacts/search/phone_search.py
+++ b/temba/contacts/search/phone_search.py
@@ -71,7 +71,7 @@ def search_contacts_resolving_phone(
             search_contacts(org, query, group=group, sort=sort, offset=offset, exclude_ids=exclude_ids)
         )
 
-    search_kwargs = dict(group=group, sort=sort, offset=offset, exclude_ids=exclude_ids)
+    search_kwargs = {"group": group, "sort": sort, "offset": offset, "exclude_ids": exclude_ids}
 
     whatsapp_query = build_phone_urn_query(WHATSAPP_SCHEME, query)
     whatsapp_results = search_contacts(org, whatsapp_query, **search_kwargs)

--- a/temba/contacts/search/phone_search.py
+++ b/temba/contacts/search/phone_search.py
@@ -1,10 +1,12 @@
 import json
 import re
 
-from temba.contacts.models import URN
 from temba.utils.whatsapp.ninth_digit import get_number_search_terms
 
 from .mailroom import SearchResults, search_contacts
+
+WHATSAPP_SCHEME = "whatsapp"
+TEL_SCHEME = "tel"
 
 _CONTACTQL_HINTS = re.compile(r"[~>=]|(?:^|\s)(?:and|or|not)\s", re.I)
 _SCHEME_HINTS = re.compile(r"(?:^|\s)(?:tel|whatsapp|twitter|email|facebook|instagram|telegram|discord)\s*[=~]", re.I)
@@ -30,6 +32,8 @@ def is_bare_phone_search(query: str, org) -> bool:
     if _IMPLICIT_PHONE.match(query):
         return True
 
+    from temba.contacts.models import URN
+
     return URN.looks_like_phone(query, org.default_country_code)
 
 
@@ -44,7 +48,7 @@ def build_phone_urn_query(scheme: str, raw_query: str) -> str:
 
     clauses = [f"{scheme} ~ {json.dumps(digits)}"]
 
-    if scheme == URN.WHATSAPP_SCHEME and terms["whatsapp_variant"]:
+    if scheme == WHATSAPP_SCHEME and terms["whatsapp_variant"]:
         clauses.append(f"{scheme} ~ {json.dumps(terms['whatsapp_variant'])}")
 
     if len(clauses) == 1:
@@ -66,11 +70,11 @@ def search_contacts_resolving_phone(
 
     search_kwargs = dict(group=group, sort=sort, offset=offset, exclude_ids=exclude_ids)
 
-    whatsapp_query = build_phone_urn_query(URN.WHATSAPP_SCHEME, query)
+    whatsapp_query = build_phone_urn_query(WHATSAPP_SCHEME, query)
     whatsapp_results = search_contacts(org, whatsapp_query, **search_kwargs)
     if whatsapp_results.total > 0:
         return ContactSearchOutcome(whatsapp_results)
 
-    tel_query = build_phone_urn_query(URN.TEL_SCHEME, query)
+    tel_query = build_phone_urn_query(TEL_SCHEME, query)
     tel_results = search_contacts(org, tel_query, **search_kwargs)
     return ContactSearchOutcome(tel_results, phone_fallback=True)

--- a/temba/contacts/search/phone_search.py
+++ b/temba/contacts/search/phone_search.py
@@ -63,6 +63,9 @@ def search_contacts_resolving_phone(
     """
     Runs contact search, resolving bare phone numbers on WhatsApp URNs first and tel URNs second.
     """
+    if query is None:
+        query = ""
+
     if not is_bare_phone_search(query, org):
         return ContactSearchOutcome(
             search_contacts(org, query, group=group, sort=sort, offset=offset, exclude_ids=exclude_ids)

--- a/temba/contacts/search/tests.py
+++ b/temba/contacts/search/tests.py
@@ -24,21 +24,23 @@ class PhoneSearchTest(TembaTest):
         self.assertFalse(is_bare_phone_search("BR.35029025746744354", self.org))
 
     def test_build_phone_urn_query(self):
-        self.assertEqual(build_phone_urn_query(WHATSAPP_SCHEME, "987654321"), 'whatsapp ~ "987654321"')
-        self.assertEqual(build_phone_urn_query(TEL_SCHEME, "987654321"), 'tel ~ "987654321"')
+        self.assertEqual(build_phone_urn_query(WHATSAPP_SCHEME, "250781111"), 'whatsapp ~ "250781111"')
+        self.assertEqual(build_phone_urn_query(TEL_SCHEME, "250781111"), 'tel ~ "250781111"')
+        self.assertEqual(
+            build_phone_urn_query(WHATSAPP_SCHEME, "987654321"),
+            '(whatsapp ~ "987654321" OR whatsapp ~ "87654321")',
+        )
 
     @patch("temba.contacts.search.phone_search.search_contacts")
     def test_search_contacts_resolving_phone(self, mock_search_contacts):
-        whatsapp_query = build_phone_urn_query(WHATSAPP_SCHEME, "987654321")
-        tel_query = build_phone_urn_query(TEL_SCHEME, "987654321")
+        whatsapp_query = build_phone_urn_query(WHATSAPP_SCHEME, "250781111")
+        tel_query = build_phone_urn_query(TEL_SCHEME, "250781111")
 
         mock_search_contacts.side_effect = [
             SearchResults(query=whatsapp_query, total=1, contact_ids=[1]),
-            SearchResults(query=tel_query, total=1, contact_ids=[2]),
-            SearchResults(query='name ~ "Joe"', total=1, contact_ids=[3]),
         ]
 
-        outcome = search_contacts_resolving_phone(self.org, "987654321")
+        outcome = search_contacts_resolving_phone(self.org, "250781111")
         self.assertFalse(outcome.phone_fallback)
         self.assertEqual(outcome.results.contact_ids, [1])
         mock_search_contacts.assert_called_once_with(
@@ -51,12 +53,13 @@ class PhoneSearchTest(TembaTest):
             SearchResults(query=tel_query, total=1, contact_ids=[2]),
         ]
 
-        outcome = search_contacts_resolving_phone(self.org, "987654321")
+        outcome = search_contacts_resolving_phone(self.org, "250781111")
         self.assertTrue(outcome.phone_fallback)
         self.assertEqual(outcome.results.contact_ids, [2])
         self.assertEqual(mock_search_contacts.call_count, 2)
 
         mock_search_contacts.reset_mock()
+        mock_search_contacts.side_effect = None
         mock_search_contacts.return_value = SearchResults(query='name ~ "Joe"', total=1, contact_ids=[3])
 
         outcome = search_contacts_resolving_phone(self.org, "Joe")

--- a/temba/contacts/search/tests.py
+++ b/temba/contacts/search/tests.py
@@ -7,8 +7,10 @@ from . import SearchException, SearchResults, elastic
 from .phone_search import (
     TEL_SCHEME,
     WHATSAPP_SCHEME,
+    ContactSearchOutcome,
     build_phone_urn_query,
     is_bare_phone_search,
+    search_contacts_for_list,
     search_contacts_resolving_phone,
 )
 
@@ -67,6 +69,16 @@ class PhoneSearchTest(TembaTest):
         mock_search_contacts.assert_called_once_with(
             self.org, "Joe", group=None, sort=None, offset=None, exclude_ids=()
         )
+
+    @patch("temba.contacts.search.phone_search.search_contacts_resolving_phone")
+    def test_search_contacts_for_list(self, mock_search_resolving_phone):
+        expected = SearchResults(query='name ~ "Joe"', total=1, contact_ids=[3])
+        mock_search_resolving_phone.return_value = ContactSearchOutcome(expected, phone_fallback=True)
+
+        results, phone_fallback = search_contacts_for_list(self.org, "Joe")
+
+        self.assertEqual(results, expected)
+        self.assertTrue(phone_fallback)
 
 
 class SearchExceptionTest(TembaTest):

--- a/temba/contacts/search/tests.py
+++ b/temba/contacts/search/tests.py
@@ -1,7 +1,64 @@
+from unittest.mock import patch
+
+from temba.contacts.models import URN
 from temba.mailroom import MailroomException
 from temba.tests import TembaTest, mock_mailroom
 
-from . import SearchException, elastic
+from . import SearchException, SearchResults, elastic
+from .phone_search import build_phone_urn_query, is_bare_phone_search, search_contacts_resolving_phone
+
+
+class PhoneSearchTest(TembaTest):
+    def test_is_bare_phone_search(self):
+        self.assertTrue(is_bare_phone_search("987654321", self.org))
+        self.assertTrue(is_bare_phone_search("+250781111111", self.org))
+        self.assertFalse(is_bare_phone_search("Joe", self.org))
+        self.assertFalse(is_bare_phone_search("age = 18", self.org))
+        self.assertFalse(is_bare_phone_search("tel ~ 1234", self.org))
+        self.assertFalse(is_bare_phone_search("whatsapp:5586987654321", self.org))
+        self.assertFalse(is_bare_phone_search("BR.35029025746744354", self.org))
+
+    def test_build_phone_urn_query(self):
+        self.assertEqual(build_phone_urn_query(URN.WHATSAPP_SCHEME, "987654321"), 'whatsapp ~ "987654321"')
+        self.assertEqual(build_phone_urn_query(URN.TEL_SCHEME, "987654321"), 'tel ~ "987654321"')
+
+    @patch("temba.contacts.search.phone_search.search_contacts")
+    def test_search_contacts_resolving_phone(self, mock_search_contacts):
+        whatsapp_query = build_phone_urn_query(URN.WHATSAPP_SCHEME, "987654321")
+        tel_query = build_phone_urn_query(URN.TEL_SCHEME, "987654321")
+
+        mock_search_contacts.side_effect = [
+            SearchResults(query=whatsapp_query, total=1, contact_ids=[1]),
+            SearchResults(query=tel_query, total=1, contact_ids=[2]),
+            SearchResults(query='name ~ "Joe"', total=1, contact_ids=[3]),
+        ]
+
+        outcome = search_contacts_resolving_phone(self.org, "987654321")
+        self.assertFalse(outcome.phone_fallback)
+        self.assertEqual(outcome.results.contact_ids, [1])
+        mock_search_contacts.assert_called_once_with(
+            self.org, whatsapp_query, group=None, sort=None, offset=None, exclude_ids=()
+        )
+
+        mock_search_contacts.reset_mock()
+        mock_search_contacts.side_effect = [
+            SearchResults(query=whatsapp_query, total=0, contact_ids=[]),
+            SearchResults(query=tel_query, total=1, contact_ids=[2]),
+        ]
+
+        outcome = search_contacts_resolving_phone(self.org, "987654321")
+        self.assertTrue(outcome.phone_fallback)
+        self.assertEqual(outcome.results.contact_ids, [2])
+        self.assertEqual(mock_search_contacts.call_count, 2)
+
+        mock_search_contacts.reset_mock()
+        mock_search_contacts.return_value = SearchResults(query='name ~ "Joe"', total=1, contact_ids=[3])
+
+        outcome = search_contacts_resolving_phone(self.org, "Joe")
+        self.assertFalse(outcome.phone_fallback)
+        mock_search_contacts.assert_called_once_with(
+            self.org, "Joe", group=None, sort=None, offset=None, exclude_ids=()
+        )
 
 
 class SearchExceptionTest(TembaTest):

--- a/temba/contacts/search/tests.py
+++ b/temba/contacts/search/tests.py
@@ -1,11 +1,16 @@
 from unittest.mock import patch
 
-from temba.contacts.models import URN
 from temba.mailroom import MailroomException
 from temba.tests import TembaTest, mock_mailroom
 
 from . import SearchException, SearchResults, elastic
-from .phone_search import build_phone_urn_query, is_bare_phone_search, search_contacts_resolving_phone
+from .phone_search import (
+    TEL_SCHEME,
+    WHATSAPP_SCHEME,
+    build_phone_urn_query,
+    is_bare_phone_search,
+    search_contacts_resolving_phone,
+)
 
 
 class PhoneSearchTest(TembaTest):
@@ -19,13 +24,13 @@ class PhoneSearchTest(TembaTest):
         self.assertFalse(is_bare_phone_search("BR.35029025746744354", self.org))
 
     def test_build_phone_urn_query(self):
-        self.assertEqual(build_phone_urn_query(URN.WHATSAPP_SCHEME, "987654321"), 'whatsapp ~ "987654321"')
-        self.assertEqual(build_phone_urn_query(URN.TEL_SCHEME, "987654321"), 'tel ~ "987654321"')
+        self.assertEqual(build_phone_urn_query(WHATSAPP_SCHEME, "987654321"), 'whatsapp ~ "987654321"')
+        self.assertEqual(build_phone_urn_query(TEL_SCHEME, "987654321"), 'tel ~ "987654321"')
 
     @patch("temba.contacts.search.phone_search.search_contacts")
     def test_search_contacts_resolving_phone(self, mock_search_contacts):
-        whatsapp_query = build_phone_urn_query(URN.WHATSAPP_SCHEME, "987654321")
-        tel_query = build_phone_urn_query(URN.TEL_SCHEME, "987654321")
+        whatsapp_query = build_phone_urn_query(WHATSAPP_SCHEME, "987654321")
+        tel_query = build_phone_urn_query(TEL_SCHEME, "987654321")
 
         mock_search_contacts.side_effect = [
             SearchResults(query=whatsapp_query, total=1, contact_ids=[1]),

--- a/temba/contacts/tests.py
+++ b/temba/contacts/tests.py
@@ -6,10 +6,6 @@ from datetime import date, datetime, timedelta
 from decimal import Decimal
 from unittest.mock import PropertyMock, call, patch
 
-import iso8601
-import pytz
-from openpyxl import load_workbook
-
 from django.conf import settings
 from django.core.files.uploadedfile import SimpleUploadedFile
 from django.core.validators import ValidationError
@@ -23,11 +19,14 @@ from django.test.utils import override_settings
 from django.urls import reverse
 from django.utils import timezone
 
+import iso8601
+import pytz
+from openpyxl import load_workbook
 from temba.airtime.models import AirtimeTransfer
 from temba.campaigns.models import Campaign, CampaignEvent, EventFire
 from temba.channels.models import Channel, ChannelEvent, ChannelLog
 from temba.contacts.search import SearchException, SearchResults, search_contacts
-from temba.contacts.search.phone_search import WHATSAPP_SCHEME, TEL_SCHEME, build_phone_urn_query
+from temba.contacts.search.phone_search import TEL_SCHEME, WHATSAPP_SCHEME, ContactSearchOutcome, build_phone_urn_query
 from temba.contacts.views import ContactCRUDL, ContactListView
 from temba.flows.models import Flow, FlowSession, FlowStart
 from temba.ivr.models import IVRCall
@@ -183,20 +182,20 @@ class ContactCRUDLTest(CRUDLTestMixin, TembaTest):
         self.assertEqual(response.context["save_dynamic_search"], True)
         self.assertIsNone(response.context["search_error"])
 
-        whatsapp_query = build_phone_urn_query(WHATSAPP_SCHEME, "987654321")
+        whatsapp_query = build_phone_urn_query(WHATSAPP_SCHEME, "250781111")
         mr_mocks.contact_search(whatsapp_query, contacts=[joe], cleaned=whatsapp_query)
 
-        response = self.client.get(list_url + "?search=987654321")
+        response = self.client.get(list_url + "?search=250781111")
         self.assertEqual(list(response.context["object_list"]), [joe])
         self.assertEqual(response.context["search"], whatsapp_query)
         self.assertFalse(response.context["search_phone_fallback"])
         self.assertIsNone(response.context["search_error"])
 
-        tel_query = build_phone_urn_query(TEL_SCHEME, "987654321")
+        tel_query = build_phone_urn_query(TEL_SCHEME, "250781111")
         mr_mocks.contact_search(whatsapp_query, contacts=[], total=0, cleaned=whatsapp_query)
         mr_mocks.contact_search(tel_query, contacts=[frank], cleaned=tel_query)
 
-        response = self.client.get(list_url + "?search=987654321")
+        response = self.client.get(list_url + "?search=250781111")
         self.assertEqual(list(response.context["object_list"]), [frank])
         self.assertEqual(response.context["search"], tel_query)
         self.assertTrue(response.context["search_phone_fallback"])
@@ -1901,9 +1900,9 @@ class ContactTest(TembaTest):
             self.assertEqual(["tel:+250782222222"], [u.urn for u in self.frank.get_urns()])
             self.assertEqual([], [u.urn for u in self.billy.get_urns()])
 
-    @patch("temba.contacts.search.omnibox.search_contacts")
+    @patch("temba.contacts.search.omnibox.search_contacts_resolving_phone")
     @mock_mailroom
-    def test_omnibox(self, mr_mocks, mock_search_contacts):
+    def test_omnibox(self, mr_mocks, mock_search_resolving_phone):
         # add a group with members and an empty group
         self.create_field("gender", "Gender")
         joe_and_frank = self.create_group("Joe and Frank", [self.joe, self.frank])
@@ -1937,23 +1936,35 @@ class ContactTest(TembaTest):
             response = self.client.get(f"{path}?{query}&v={version}")
             return response.json()["results"]
 
+        def omnibox_search_results(results):
+            if isinstance(results, list):
+                return [ContactSearchOutcome(result) for result in results]
+            return ContactSearchOutcome(results)
+
+        def resolve_phone_search(org, query, **kwargs):
+            return ContactSearchOutcome(
+                search_contacts(org, query, group=kwargs.get("group"), sort=kwargs.get("sort"))
+            )
+
         # omnibox view will try to search it as a contact then as a URN so 2 calls to mailroom search endpoint
         mr_mocks.error("ooh that doesn't look right")
         mr_mocks.error("ooh that doesn't look right again")
 
         # for this one test we want to call the actual search method..
-        mock_search_contacts.side_effect = search_contacts
+        mock_search_resolving_phone.side_effect = resolve_phone_search
 
         # error is swallowed and we show no results
         self.assertEqual([], omnibox_request("search=-123`213"))
 
         with self.assertNumQueries(17):
-            mock_search_contacts.side_effect = [
-                SearchResults(
-                    query="", total=4, contact_ids=[self.billy.id, self.frank.id, self.joe.id, self.voldemort.id]
-                ),
-                SearchResults(query="", total=3, contact_ids=[]),
-            ]
+            mock_search_resolving_phone.side_effect = omnibox_search_results(
+                [
+                    SearchResults(
+                        query="", total=4, contact_ids=[self.billy.id, self.frank.id, self.joe.id, self.voldemort.id]
+                    ),
+                    SearchResults(query="", total=3, contact_ids=[]),
+                ]
+            )
 
             self.assertEqual(
                 [
@@ -1971,10 +1982,12 @@ class ContactTest(TembaTest):
             )
 
         with self.assertNumQueries(20):
-            mock_search_contacts.side_effect = [
-                SearchResults(query="", total=2, contact_ids=[self.billy.id, self.frank.id]),
-                SearchResults(query="", total=2, contact_ids=[self.voldemort.id, self.frank.id]),
-            ]
+            mock_search_resolving_phone.side_effect = omnibox_search_results(
+                [
+                    SearchResults(query="", total=2, contact_ids=[self.billy.id, self.frank.id]),
+                    SearchResults(query="", total=2, contact_ids=[self.voldemort.id, self.frank.id]),
+                ]
+            )
 
             self.assertEqual(
                 [
@@ -2001,10 +2014,12 @@ class ContactTest(TembaTest):
             )
 
         with self.assertNumQueries(17):
-            mock_search_contacts.side_effect = [
-                SearchResults(query="", total=2, contact_ids=[self.billy.id, self.frank.id]),
-                SearchResults(query="", total=0, contact_ids=[]),
-            ]
+            mock_search_resolving_phone.side_effect = omnibox_search_results(
+                [
+                    SearchResults(query="", total=2, contact_ids=[self.billy.id, self.frank.id]),
+                    SearchResults(query="", total=0, contact_ids=[]),
+                ]
+            )
 
             self.assertEqual(
                 [
@@ -2040,12 +2055,14 @@ class ContactTest(TembaTest):
             omnibox_request("types=s"),
         )
 
-        mock_search_contacts.side_effect = [
-            SearchResults(
-                query="", total=4, contact_ids=[self.billy.id, self.frank.id, self.joe.id, self.voldemort.id]
-            ),
-            SearchResults(query="", total=3, contact_ids=[self.voldemort.id, self.joe.id, self.frank.id]),
-        ]
+        mock_search_resolving_phone.side_effect = omnibox_search_results(
+            [
+                SearchResults(
+                    query="", total=4, contact_ids=[self.billy.id, self.frank.id, self.joe.id, self.voldemort.id]
+                ),
+                SearchResults(query="", total=3, contact_ids=[self.voldemort.id, self.joe.id, self.frank.id]),
+            ]
+        )
         self.assertEqual(
             [
                 {"id": f"c-{self.billy.uuid}", "text": "Billy Nophone", "extra": ""},
@@ -2060,10 +2077,12 @@ class ContactTest(TembaTest):
         )
 
         # search for Frank by phone
-        mock_search_contacts.side_effect = [
-            SearchResults(query="name ~ 222", total=0, contact_ids=[]),
-            SearchResults(query="urn ~ 222", total=1, contact_ids=[self.frank.id]),
-        ]
+        mock_search_resolving_phone.side_effect = omnibox_search_results(
+            [
+                SearchResults(query="name ~ 222", total=0, contact_ids=[]),
+                SearchResults(query="urn ~ 222", total=1, contact_ids=[self.frank.id]),
+            ]
+        )
         self.assertEqual(
             [{"id": f"u-{frank_tel.id}", "text": "250782222222", "extra": "Frank Smith", "scheme": "tel"}],
             omnibox_request("search=222"),
@@ -2076,10 +2095,12 @@ class ContactTest(TembaTest):
         Channel.create(self.org, self.user, "RW", "EX", schemes=[URN.TEL_SCHEME])
 
         # search for Joe - match on last name and twitter handle
-        mock_search_contacts.side_effect = [
-            SearchResults(query="name ~ blow", total=1, contact_ids=[self.joe.id]),
-            SearchResults(query="urn ~ blow", total=1, contact_ids=[self.joe.id]),
-        ]
+        mock_search_resolving_phone.side_effect = omnibox_search_results(
+            [
+                SearchResults(query="name ~ blow", total=1, contact_ids=[self.joe.id]),
+                SearchResults(query="urn ~ blow", total=1, contact_ids=[self.joe.id]),
+            ]
+        )
         self.assertEqual(
             [
                 dict(id="c-%s" % self.joe.uuid, text="Joe Blow", extra="blow80"),
@@ -2121,7 +2142,9 @@ class ContactTest(TembaTest):
         )
 
         with AnonymousOrg(self.org):
-            mock_search_contacts.side_effect = [SearchResults(query="", total=1, contact_ids=[self.billy.id])]
+            mock_search_resolving_phone.side_effect = omnibox_search_results(
+                [SearchResults(query="", total=1, contact_ids=[self.billy.id])]
+            )
             self.assertEqual(
                 [
                     # all 3 groups...
@@ -2136,7 +2159,9 @@ class ContactTest(TembaTest):
             )
 
             # same search but with v2 format
-            mock_search_contacts.side_effect = [SearchResults(query="", total=1, contact_ids=[self.billy.id])]
+            mock_search_resolving_phone.side_effect = omnibox_search_results(
+                [SearchResults(query="", total=1, contact_ids=[self.billy.id])]
+            )
             self.assertEqual(
                 [
                     # all 3 groups A-Z

--- a/temba/contacts/tests.py
+++ b/temba/contacts/tests.py
@@ -27,7 +27,7 @@ from temba.airtime.models import AirtimeTransfer
 from temba.campaigns.models import Campaign, CampaignEvent, EventFire
 from temba.channels.models import Channel, ChannelEvent, ChannelLog
 from temba.contacts.search import SearchException, SearchResults, search_contacts
-from temba.contacts.search.phone_search import build_phone_urn_query
+from temba.contacts.search.phone_search import WHATSAPP_SCHEME, TEL_SCHEME, build_phone_urn_query
 from temba.contacts.views import ContactCRUDL, ContactListView
 from temba.flows.models import Flow, FlowSession, FlowStart
 from temba.ivr.models import IVRCall
@@ -183,7 +183,7 @@ class ContactCRUDLTest(CRUDLTestMixin, TembaTest):
         self.assertEqual(response.context["save_dynamic_search"], True)
         self.assertIsNone(response.context["search_error"])
 
-        whatsapp_query = build_phone_urn_query(URN.WHATSAPP_SCHEME, "987654321")
+        whatsapp_query = build_phone_urn_query(WHATSAPP_SCHEME, "987654321")
         mr_mocks.contact_search(whatsapp_query, contacts=[joe], cleaned=whatsapp_query)
 
         response = self.client.get(list_url + "?search=987654321")
@@ -192,7 +192,7 @@ class ContactCRUDLTest(CRUDLTestMixin, TembaTest):
         self.assertFalse(response.context["search_phone_fallback"])
         self.assertIsNone(response.context["search_error"])
 
-        tel_query = build_phone_urn_query(URN.TEL_SCHEME, "987654321")
+        tel_query = build_phone_urn_query(TEL_SCHEME, "987654321")
         mr_mocks.contact_search(whatsapp_query, contacts=[], total=0, cleaned=whatsapp_query)
         mr_mocks.contact_search(tel_query, contacts=[frank], cleaned=tel_query)
 

--- a/temba/contacts/tests.py
+++ b/temba/contacts/tests.py
@@ -27,6 +27,7 @@ from temba.airtime.models import AirtimeTransfer
 from temba.campaigns.models import Campaign, CampaignEvent, EventFire
 from temba.channels.models import Channel, ChannelEvent, ChannelLog
 from temba.contacts.search import SearchException, SearchResults, search_contacts
+from temba.contacts.search.phone_search import build_phone_urn_query
 from temba.contacts.views import ContactCRUDL, ContactListView
 from temba.flows.models import Flow, FlowSession, FlowStart
 from temba.ivr.models import IVRCall
@@ -180,6 +181,25 @@ class ContactCRUDLTest(CRUDLTestMixin, TembaTest):
         self.assertEqual(list(response.context["object_list"]), [joe])
         self.assertEqual(response.context["search"], 'name ~ "Joe"')
         self.assertEqual(response.context["save_dynamic_search"], True)
+        self.assertIsNone(response.context["search_error"])
+
+        whatsapp_query = build_phone_urn_query(URN.WHATSAPP_SCHEME, "987654321")
+        mr_mocks.contact_search(whatsapp_query, contacts=[joe], cleaned=whatsapp_query)
+
+        response = self.client.get(list_url + "?search=987654321")
+        self.assertEqual(list(response.context["object_list"]), [joe])
+        self.assertEqual(response.context["search"], whatsapp_query)
+        self.assertFalse(response.context["search_phone_fallback"])
+        self.assertIsNone(response.context["search_error"])
+
+        tel_query = build_phone_urn_query(URN.TEL_SCHEME, "987654321")
+        mr_mocks.contact_search(whatsapp_query, contacts=[], total=0, cleaned=whatsapp_query)
+        mr_mocks.contact_search(tel_query, contacts=[frank], cleaned=tel_query)
+
+        response = self.client.get(list_url + "?search=987654321")
+        self.assertEqual(list(response.context["object_list"]), [frank])
+        self.assertEqual(response.context["search"], tel_query)
+        self.assertTrue(response.context["search_phone_fallback"])
         self.assertIsNone(response.context["search_error"])
 
         with AnonymousOrg(self.org):

--- a/temba/contacts/tests.py
+++ b/temba/contacts/tests.py
@@ -6,6 +6,10 @@ from datetime import date, datetime, timedelta
 from decimal import Decimal
 from unittest.mock import PropertyMock, call, patch
 
+import iso8601
+import pytz
+from openpyxl import load_workbook
+
 from django.conf import settings
 from django.core.files.uploadedfile import SimpleUploadedFile
 from django.core.validators import ValidationError
@@ -19,9 +23,6 @@ from django.test.utils import override_settings
 from django.urls import reverse
 from django.utils import timezone
 
-import iso8601
-import pytz
-from openpyxl import load_workbook
 from temba.airtime.models import AirtimeTransfer
 from temba.campaigns.models import Campaign, CampaignEvent, EventFire
 from temba.channels.models import Channel, ChannelEvent, ChannelLog
@@ -1900,9 +1901,10 @@ class ContactTest(TembaTest):
             self.assertEqual(["tel:+250782222222"], [u.urn for u in self.frank.get_urns()])
             self.assertEqual([], [u.urn for u in self.billy.get_urns()])
 
+    @patch("temba.contacts.search.omnibox.search_contacts")
     @patch("temba.contacts.search.omnibox.search_contacts_resolving_phone")
     @mock_mailroom
-    def test_omnibox(self, mr_mocks, mock_search_resolving_phone):
+    def test_omnibox(self, mr_mocks, mock_search_resolving_phone, mock_search_contacts):
         # add a group with members and an empty group
         self.create_field("gender", "Gender")
         joe_and_frank = self.create_group("Joe and Frank", [self.joe, self.frank])
@@ -1946,25 +1948,30 @@ class ContactTest(TembaTest):
                 search_contacts(org, query, group=kwargs.get("group"), sort=kwargs.get("sort"))
             )
 
+        def set_contact_search_mocks(*results):
+            mock_search_resolving_phone.side_effect = omnibox_search_results(list(results))
+
+        def set_urn_search_mocks(*results):
+            mock_search_contacts.side_effect = list(results)
+
         # omnibox view will try to search it as a contact then as a URN so 2 calls to mailroom search endpoint
         mr_mocks.error("ooh that doesn't look right")
         mr_mocks.error("ooh that doesn't look right again")
 
         # for this one test we want to call the actual search method..
         mock_search_resolving_phone.side_effect = resolve_phone_search
+        mock_search_contacts.side_effect = search_contacts
 
         # error is swallowed and we show no results
         self.assertEqual([], omnibox_request("search=-123`213"))
 
         with self.assertNumQueries(17):
-            mock_search_resolving_phone.side_effect = omnibox_search_results(
-                [
-                    SearchResults(
-                        query="", total=4, contact_ids=[self.billy.id, self.frank.id, self.joe.id, self.voldemort.id]
-                    ),
-                    SearchResults(query="", total=3, contact_ids=[]),
-                ]
+            set_contact_search_mocks(
+                SearchResults(
+                    query="", total=4, contact_ids=[self.billy.id, self.frank.id, self.joe.id, self.voldemort.id]
+                )
             )
+            set_urn_search_mocks(SearchResults(query="", total=3, contact_ids=[]))
 
             self.assertEqual(
                 [
@@ -1982,12 +1989,8 @@ class ContactTest(TembaTest):
             )
 
         with self.assertNumQueries(20):
-            mock_search_resolving_phone.side_effect = omnibox_search_results(
-                [
-                    SearchResults(query="", total=2, contact_ids=[self.billy.id, self.frank.id]),
-                    SearchResults(query="", total=2, contact_ids=[self.voldemort.id, self.frank.id]),
-                ]
-            )
+            set_contact_search_mocks(SearchResults(query="", total=2, contact_ids=[self.billy.id, self.frank.id]))
+            set_urn_search_mocks(SearchResults(query="", total=2, contact_ids=[self.voldemort.id, self.frank.id]))
 
             self.assertEqual(
                 [
@@ -2014,12 +2017,8 @@ class ContactTest(TembaTest):
             )
 
         with self.assertNumQueries(17):
-            mock_search_resolving_phone.side_effect = omnibox_search_results(
-                [
-                    SearchResults(query="", total=2, contact_ids=[self.billy.id, self.frank.id]),
-                    SearchResults(query="", total=0, contact_ids=[]),
-                ]
-            )
+            set_contact_search_mocks(SearchResults(query="", total=2, contact_ids=[self.billy.id, self.frank.id]))
+            set_urn_search_mocks(SearchResults(query="", total=0, contact_ids=[]))
 
             self.assertEqual(
                 [
@@ -2055,13 +2054,13 @@ class ContactTest(TembaTest):
             omnibox_request("types=s"),
         )
 
-        mock_search_resolving_phone.side_effect = omnibox_search_results(
-            [
-                SearchResults(
-                    query="", total=4, contact_ids=[self.billy.id, self.frank.id, self.joe.id, self.voldemort.id]
-                ),
-                SearchResults(query="", total=3, contact_ids=[self.voldemort.id, self.joe.id, self.frank.id]),
-            ]
+        set_contact_search_mocks(
+            SearchResults(
+                query="", total=4, contact_ids=[self.billy.id, self.frank.id, self.joe.id, self.voldemort.id]
+            )
+        )
+        set_urn_search_mocks(
+            SearchResults(query="", total=3, contact_ids=[self.voldemort.id, self.joe.id, self.frank.id])
         )
         self.assertEqual(
             [
@@ -2077,12 +2076,8 @@ class ContactTest(TembaTest):
         )
 
         # search for Frank by phone
-        mock_search_resolving_phone.side_effect = omnibox_search_results(
-            [
-                SearchResults(query="name ~ 222", total=0, contact_ids=[]),
-                SearchResults(query="urn ~ 222", total=1, contact_ids=[self.frank.id]),
-            ]
-        )
+        set_contact_search_mocks(SearchResults(query="name ~ 222", total=0, contact_ids=[]))
+        set_urn_search_mocks(SearchResults(query="urn ~ 222", total=1, contact_ids=[self.frank.id]))
         self.assertEqual(
             [{"id": f"u-{frank_tel.id}", "text": "250782222222", "extra": "Frank Smith", "scheme": "tel"}],
             omnibox_request("search=222"),
@@ -2095,12 +2090,8 @@ class ContactTest(TembaTest):
         Channel.create(self.org, self.user, "RW", "EX", schemes=[URN.TEL_SCHEME])
 
         # search for Joe - match on last name and twitter handle
-        mock_search_resolving_phone.side_effect = omnibox_search_results(
-            [
-                SearchResults(query="name ~ blow", total=1, contact_ids=[self.joe.id]),
-                SearchResults(query="urn ~ blow", total=1, contact_ids=[self.joe.id]),
-            ]
-        )
+        set_contact_search_mocks(SearchResults(query="name ~ blow", total=1, contact_ids=[self.joe.id]))
+        set_urn_search_mocks(SearchResults(query="urn ~ blow", total=1, contact_ids=[self.joe.id]))
         self.assertEqual(
             [
                 dict(id="c-%s" % self.joe.uuid, text="Joe Blow", extra="blow80"),
@@ -2142,9 +2133,7 @@ class ContactTest(TembaTest):
         )
 
         with AnonymousOrg(self.org):
-            mock_search_resolving_phone.side_effect = omnibox_search_results(
-                [SearchResults(query="", total=1, contact_ids=[self.billy.id])]
-            )
+            set_contact_search_mocks(SearchResults(query="", total=1, contact_ids=[self.billy.id]))
             self.assertEqual(
                 [
                     # all 3 groups...
@@ -2159,9 +2148,7 @@ class ContactTest(TembaTest):
             )
 
             # same search but with v2 format
-            mock_search_resolving_phone.side_effect = omnibox_search_results(
-                [SearchResults(query="", total=1, contact_ids=[self.billy.id])]
-            )
+            set_contact_search_mocks(SearchResults(query="", total=1, contact_ids=[self.billy.id]))
             self.assertEqual(
                 [
                     # all 3 groups A-Z

--- a/temba/contacts/views.py
+++ b/temba/contacts/views.py
@@ -2,20 +2,6 @@ import logging
 from collections import OrderedDict
 from datetime import timedelta
 
-import iso8601
-from smartmin.views import (
-    SmartCreateView,
-    SmartCRUDL,
-    SmartDeleteView,
-    SmartFormView,
-    SmartListView,
-    SmartReadView,
-    SmartTemplateView,
-    SmartUpdateView,
-    SmartView,
-    smart_url,
-)
-
 from django import forms
 from django.conf import settings
 from django.contrib import messages
@@ -33,6 +19,19 @@ from django.utils.http import is_safe_url, urlquote_plus
 from django.utils.translation import ugettext_lazy as _
 from django.views import View
 
+import iso8601
+from smartmin.views import (
+    SmartCreateView,
+    SmartCRUDL,
+    SmartDeleteView,
+    SmartFormView,
+    SmartListView,
+    SmartReadView,
+    SmartTemplateView,
+    SmartUpdateView,
+    SmartView,
+    smart_url,
+)
 from temba.archives.models import Archive
 from temba.channels.models import Channel
 from temba.contacts.templatetags.contacts import MISSING_VALUE
@@ -74,8 +73,8 @@ from .models import (
     ExportContactsTask,
 )
 from .search import SearchException, parse_query
-from .search.phone_search import search_contacts_resolving_phone
 from .search.omnibox import omnibox_query, omnibox_results_to_dict
+from .search.phone_search import search_contacts_resolving_phone
 from .tasks import export_contacts_task
 
 logger = logging.getLogger(__name__)

--- a/temba/contacts/views.py
+++ b/temba/contacts/views.py
@@ -73,7 +73,8 @@ from .models import (
     ContactURN,
     ExportContactsTask,
 )
-from .search import SearchException, parse_query, search_contacts_resolving_phone
+from .search import SearchException, parse_query
+from .search.phone_search import search_contacts_resolving_phone
 from .search.omnibox import omnibox_query, omnibox_results_to_dict
 from .tasks import export_contacts_task
 

--- a/temba/contacts/views.py
+++ b/temba/contacts/views.py
@@ -75,7 +75,7 @@ from .models import (
 )
 from .search import SearchException, parse_query
 from .search.omnibox import omnibox_query, omnibox_results_to_dict
-from .search.phone_search import search_contacts_resolving_phone
+from .search.phone_search import search_contacts_for_list
 from .tasks import export_contacts_task
 
 logger = logging.getLogger(__name__)
@@ -319,11 +319,9 @@ class ContactListView(SpaMixin, OrgPermsMixin, BulkActionMixin, SmartListView):
                 exclude_ids = []
 
             try:
-                outcome = search_contacts_resolving_phone(
+                results, self.search_phone_fallback = search_contacts_for_list(
                     org, search_query, group=self.group, sort=sort_on, offset=offset, exclude_ids=exclude_ids
                 )
-                results = outcome.results
-                self.search_phone_fallback = outcome.phone_fallback
                 self.parsed_query = results.query if len(results.query) > 0 else None
                 self.save_dynamic_search = results.metadata.allow_as_group
 
@@ -1125,10 +1123,7 @@ class ContactCRUDL(SmartCRUDL):
                 return JsonResponse({"total": 0, "sample": [], "fields": {}})
 
             try:
-                outcome = search_contacts_resolving_phone(
-                    org, query, group=org.active_contacts_group, sort="-created_on"
-                )
-                results = outcome.results
+                results, _ = search_contacts_for_list(org, query, group=org.active_contacts_group, sort="-created_on")
                 summary = {
                     "total": results.total,
                     "query": results.query,

--- a/temba/contacts/views.py
+++ b/temba/contacts/views.py
@@ -2,6 +2,20 @@ import logging
 from collections import OrderedDict
 from datetime import timedelta
 
+import iso8601
+from smartmin.views import (
+    SmartCreateView,
+    SmartCRUDL,
+    SmartDeleteView,
+    SmartFormView,
+    SmartListView,
+    SmartReadView,
+    SmartTemplateView,
+    SmartUpdateView,
+    SmartView,
+    smart_url,
+)
+
 from django import forms
 from django.conf import settings
 from django.contrib import messages
@@ -19,19 +33,6 @@ from django.utils.http import is_safe_url, urlquote_plus
 from django.utils.translation import ugettext_lazy as _
 from django.views import View
 
-import iso8601
-from smartmin.views import (
-    SmartCreateView,
-    SmartCRUDL,
-    SmartDeleteView,
-    SmartFormView,
-    SmartListView,
-    SmartReadView,
-    SmartTemplateView,
-    SmartUpdateView,
-    SmartView,
-    smart_url,
-)
 from temba.archives.models import Archive
 from temba.channels.models import Channel
 from temba.contacts.templatetags.contacts import MISSING_VALUE

--- a/temba/contacts/views.py
+++ b/temba/contacts/views.py
@@ -73,7 +73,7 @@ from .models import (
     ContactURN,
     ExportContactsTask,
 )
-from .search import SearchException, parse_query, search_contacts
+from .search import SearchException, parse_query, search_contacts_resolving_phone
 from .search.omnibox import omnibox_query, omnibox_results_to_dict
 from .tasks import export_contacts_task
 
@@ -191,6 +191,7 @@ class ContactListView(SpaMixin, OrgPermsMixin, BulkActionMixin, SmartListView):
 
     parsed_query = None
     save_dynamic_search = None
+    search_phone_fallback = False
 
     sort_field = None
     sort_direction = None
@@ -317,9 +318,11 @@ class ContactListView(SpaMixin, OrgPermsMixin, BulkActionMixin, SmartListView):
                 exclude_ids = []
 
             try:
-                results = search_contacts(
+                outcome = search_contacts_resolving_phone(
                     org, search_query, group=self.group, sort=sort_on, offset=offset, exclude_ids=exclude_ids
                 )
+                results = outcome.results
+                self.search_phone_fallback = outcome.phone_fallback
                 self.parsed_query = results.query if len(results.query) > 0 else None
                 self.save_dynamic_search = results.metadata.allow_as_group
 
@@ -371,6 +374,7 @@ class ContactListView(SpaMixin, OrgPermsMixin, BulkActionMixin, SmartListView):
         if self.parsed_query is not None:
             context["search"] = self.parsed_query
             context["save_dynamic_search"] = self.save_dynamic_search
+            context["search_phone_fallback"] = self.search_phone_fallback
 
         return context
 
@@ -1120,7 +1124,10 @@ class ContactCRUDL(SmartCRUDL):
                 return JsonResponse({"total": 0, "sample": [], "fields": {}})
 
             try:
-                results = search_contacts(org, query, group=org.active_contacts_group, sort="-created_on")
+                outcome = search_contacts_resolving_phone(
+                    org, query, group=org.active_contacts_group, sort="-created_on"
+                )
+                results = outcome.results
                 summary = {
                     "total": results.total,
                     "query": results.query,

--- a/templates/contacts/contact_list.haml
+++ b/templates/contacts/contact_list.haml
@@ -214,10 +214,16 @@
                     =search_error
               -elif search
                 .mb-4.ml-1.text-base.leading-relaxed
-                  -blocktrans with results_count=paginator.count|intcomma count cc=paginator.count
-                    Found {{ results_count }} contact matching <i>{{search}}</i>.
-                    -plural
-                      Found {{ results_count }} contacts matching <i>{{search}}</i>.
+                  -if search_phone_fallback
+                    -blocktrans with results_count=paginator.count|intcomma count cc=paginator.count
+                      Found {{ results_count }} contact matching <i>{{search}}</i> (phone after WhatsApp).
+                      -plural
+                        Found {{ results_count }} contacts matching <i>{{search}}</i> (phone after WhatsApp).
+                  -else
+                    -blocktrans with results_count=paginator.count|intcomma count cc=paginator.count
+                      Found {{ results_count }} contact matching <i>{{search}}</i>.
+                      -plural
+                        Found {{ results_count }} contacts matching <i>{{search}}</i>.
 
               .shadow.rounded-lg
                 -include "contacts/contact_list_include.haml"


### PR DESCRIPTION
Bare phone queries in the contact list, omnibox, and search API now try
whatsapp ~ first and fall back to tel ~ when no matches are found.