### PR TITLE
fix: handle LockNotOwnedError in nonoverlapping tasks

### DIFF
--- a/WENI-CHANGELOG.md
+++ b/WENI-CHANGELOG.md
@@ -1,7 +1,3 @@
-3.90.3
-----------
-* fix: handle lock not owned error in nonoverlapping tasks
-
 3.90.2
 ----------
 * fix: guard broadcast statistics sent/delivered counters against out-of-order DLRs

--- a/WENI-CHANGELOG.md
+++ b/WENI-CHANGELOG.md
@@ -1,3 +1,7 @@
+3.90.3
+----------
+* fix: handle lock not owned error in nonoverlapping tasks
+
 3.90.2
 ----------
 * fix: guard broadcast statistics sent/delivered counters against out-of-order DLRs

--- a/temba/classifiers/tasks.py
+++ b/temba/classifiers/tasks.py
@@ -7,7 +7,7 @@ from .models import Classifier
 logger = logging.getLogger(__name__)
 
 
-@nonoverlapping_task(track_started=True, name="sync_classifier_intents", lock_timeout=600)
+@nonoverlapping_task(track_started=True, name="sync_classifier_intents", lock_timeout=600, use_watchdog=True)
 def sync_classifier_intents(id=None):
     classifiers = Classifier.objects.filter(is_active=True)
     if id:

--- a/temba/utils/celery.py
+++ b/temba/utils/celery.py
@@ -70,14 +70,7 @@ def nonoverlapping_task(*task_args, **task_kwargs):
                                 daemon=True,
                             )
                             watchdog.start()
-
-                            try:
-                                # Execute the actual task
-                                task_func(*exec_args, **exec_kwargs)
-                            finally:
-                                # The lock will be released by the context manager
-                                # The watchdog thread will stop when it can't find the lock
-                                pass
+                            task_func(*exec_args, **exec_kwargs)
                         else:
                             # Execute without watchdog
                             task_func(*exec_args, **exec_kwargs)

--- a/temba/utils/celery.py
+++ b/temba/utils/celery.py
@@ -1,10 +1,14 @@
+import logging
 import threading
 import time
 from functools import wraps
 
 from django_redis import get_redis_connection
+from redis.exceptions import LockNotOwnedError
 
 from celery import shared_task
+
+logger = logging.getLogger(__name__)
 
 # for tasks using a redis lock to prevent overlapping this is the default timeout for the lock
 DEFAULT_TASK_LOCK_TIMEOUT = 900
@@ -56,26 +60,33 @@ def nonoverlapping_task(*task_args, **task_kwargs):
             if r.get(lock_key):
                 print("Skipping task %s to prevent overlapping" % task_name)
             else:
-                with r.lock(lock_key, timeout=lock_timeout):
-                    if use_watchdog:
-                        # Start watchdog thread to extend lock TTL
-                        watchdog = threading.Thread(
-                            target=extend_lock,
-                            args=(r, lock_key, lock_timeout),
-                            daemon=True,
-                        )
-                        watchdog.start()
+                try:
+                    with r.lock(lock_key, timeout=lock_timeout):
+                        if use_watchdog:
+                            # Start watchdog thread to extend lock TTL
+                            watchdog = threading.Thread(
+                                target=extend_lock,
+                                args=(r, lock_key, lock_timeout),
+                                daemon=True,
+                            )
+                            watchdog.start()
 
-                        try:
-                            # Execute the actual task
+                            try:
+                                # Execute the actual task
+                                task_func(*exec_args, **exec_kwargs)
+                            finally:
+                                # The lock will be released by the context manager
+                                # The watchdog thread will stop when it can't find the lock
+                                pass
+                        else:
+                            # Execute without watchdog
                             task_func(*exec_args, **exec_kwargs)
-                        finally:
-                            # The lock will be released by the context manager
-                            # The watchdog thread will stop when it can't find the lock
-                            pass
-                    else:
-                        # Execute without watchdog
-                        task_func(*exec_args, **exec_kwargs)
+                except LockNotOwnedError:
+                    logger.warning(
+                        "Lock %s expired before task %s finished releasing",
+                        lock_key,
+                        task_name,
+                    )
 
         return shared_task(*task_args, **task_kwargs)(wrapper)
 

--- a/temba/utils/celery.py
+++ b/temba/utils/celery.py
@@ -91,9 +91,7 @@ def nonoverlapping_task(*task_args, **task_kwargs):
                 logger.info("Skipping task %s to prevent overlapping", task_name)
                 return
 
-            _run_with_task_lock(
-                r, lock_key, lock_timeout, use_watchdog, task_name, task_func, exec_args, exec_kwargs
-            )
+            _run_with_task_lock(r, lock_key, lock_timeout, use_watchdog, task_name, task_func, exec_args, exec_kwargs)
 
         return shared_task(*task_args, **task_kwargs)(wrapper)
 

--- a/temba/utils/celery.py
+++ b/temba/utils/celery.py
@@ -88,7 +88,7 @@ def nonoverlapping_task(*task_args, **task_kwargs):
             lock_timeout = _resolve_lock_timeout(task_kwargs)
 
             if r.get(lock_key):
-                print("Skipping task %s to prevent overlapping" % task_name)
+                logger.info("Skipping task %s to prevent overlapping", task_name)
                 return
 
             _run_with_task_lock(

--- a/temba/utils/celery.py
+++ b/temba/utils/celery.py
@@ -32,6 +32,40 @@ def extend_lock(redis_client, lock_key, lock_timeout):
         time.sleep(LOCK_REFRESH_INTERVAL)
 
 
+def _resolve_lock_timeout(task_kwargs):
+    lock_timeout = task_kwargs.pop("lock_timeout", None)
+    if lock_timeout is not None:
+        return lock_timeout
+
+    return task_kwargs.get("time_limit", DEFAULT_TASK_LOCK_TIMEOUT)
+
+
+def _start_lock_watchdog(redis_client, lock_key, lock_timeout):
+    watchdog = threading.Thread(
+        target=extend_lock,
+        args=(redis_client, lock_key, lock_timeout),
+        daemon=True,
+    )
+    watchdog.start()
+
+
+def _run_with_task_lock(
+    redis_client, lock_key, lock_timeout, use_watchdog, task_name, task_func, exec_args, exec_kwargs
+):
+    try:
+        with redis_client.lock(lock_key, timeout=lock_timeout):
+            if use_watchdog:
+                _start_lock_watchdog(redis_client, lock_key, lock_timeout)
+
+            task_func(*exec_args, **exec_kwargs)
+    except LockNotOwnedError:
+        logger.warning(
+            "Lock %s expired before task %s finished releasing",
+            lock_key,
+            task_name,
+        )
+
+
 def nonoverlapping_task(*task_args, **task_kwargs):
     """
     Decorator to create a task whose executions are prevented from overlapping by a redis lock.
@@ -51,35 +85,15 @@ def nonoverlapping_task(*task_args, **task_kwargs):
 
             # lock key can be provided or defaults to celery-task-lock:<task_name>
             lock_key = task_kwargs.pop("lock_key", "celery-task-lock:" + task_name)
-
-            # lock timeout can be provided or defaults to task hard time limit
-            lock_timeout = task_kwargs.pop("lock_timeout", None)
-            if lock_timeout is None:
-                lock_timeout = task_kwargs.get("time_limit", DEFAULT_TASK_LOCK_TIMEOUT)
+            lock_timeout = _resolve_lock_timeout(task_kwargs)
 
             if r.get(lock_key):
                 print("Skipping task %s to prevent overlapping" % task_name)
-            else:
-                try:
-                    with r.lock(lock_key, timeout=lock_timeout):
-                        if use_watchdog:
-                            # Start watchdog thread to extend lock TTL
-                            watchdog = threading.Thread(
-                                target=extend_lock,
-                                args=(r, lock_key, lock_timeout),
-                                daemon=True,
-                            )
-                            watchdog.start()
-                            task_func(*exec_args, **exec_kwargs)
-                        else:
-                            # Execute without watchdog
-                            task_func(*exec_args, **exec_kwargs)
-                except LockNotOwnedError:
-                    logger.warning(
-                        "Lock %s expired before task %s finished releasing",
-                        lock_key,
-                        task_name,
-                    )
+                return
+
+            _run_with_task_lock(
+                r, lock_key, lock_timeout, use_watchdog, task_name, task_func, exec_args, exec_kwargs
+            )
 
         return shared_task(*task_args, **task_kwargs)(wrapper)
 

--- a/temba/utils/tests.py
+++ b/temba/utils/tests.py
@@ -13,6 +13,7 @@ import intercom.errors
 import pytz
 from django_redis import get_redis_connection
 from openpyxl import load_workbook
+from redis.exceptions import LockNotOwnedError
 from smartmin.tests import SmartminTest
 
 from django.conf import settings
@@ -36,8 +37,6 @@ from temba.utils.templatetags.temba import format_datetime
 
 from . import chunk_list, countries, format_number, languages, percentage, redact, sizeof_fmt, str_to_bool
 from .cache import get_cacheable_attr, get_cacheable_result, incrby_existing
-from redis.exceptions import LockNotOwnedError
-
 from .celery import nonoverlapping_task
 from .dates import datetime_to_str, datetime_to_timestamp, timestamp_to_datetime
 from .email import is_valid_address, send_simple_email
@@ -729,9 +728,7 @@ class CeleryTest(TembaTest):
 
         mock_lock = MagicMock()
         mock_lock.__enter__ = MagicMock(return_value=mock_lock)
-        mock_lock.__exit__ = MagicMock(
-            side_effect=LockNotOwnedError("Cannot release a lock that's no longer owned")
-        )
+        mock_lock.__exit__ = MagicMock(side_effect=LockNotOwnedError("Cannot release a lock that's no longer owned"))
         mock_redis_lock.return_value = mock_lock
 
         @nonoverlapping_task()

--- a/temba/utils/tests.py
+++ b/temba/utils/tests.py
@@ -36,6 +36,8 @@ from temba.utils.templatetags.temba import format_datetime
 
 from . import chunk_list, countries, format_number, languages, percentage, redact, sizeof_fmt, str_to_bool
 from .cache import get_cacheable_attr, get_cacheable_result, incrby_existing
+from redis.exceptions import LockNotOwnedError
+
 from .celery import nonoverlapping_task
 from .dates import datetime_to_str, datetime_to_timestamp, timestamp_to_datetime
 from .email import is_valid_address, send_simple_email
@@ -718,6 +720,27 @@ class CeleryTest(TembaTest):
         mock_redis_get.assert_called_once_with("celery-task-lock:test_task1")
         self.assertEqual(mock_redis_lock.call_count, 0)
         self.assertEqual(task_calls, ["1-11-12", "2-21-22", "3-31-32"])
+
+    @patch("redis.client.StrictRedis.lock")
+    @patch("redis.client.StrictRedis.get")
+    def test_nonoverlapping_task_lock_expired_on_release(self, mock_redis_get, mock_redis_lock):
+        mock_redis_get.return_value = None
+        task_calls = []
+
+        mock_lock = MagicMock()
+        mock_lock.__enter__ = MagicMock(return_value=mock_lock)
+        mock_lock.__exit__ = MagicMock(
+            side_effect=LockNotOwnedError("Cannot release a lock that's no longer owned")
+        )
+        mock_redis_lock.return_value = mock_lock
+
+        @nonoverlapping_task()
+        def test_task(foo, bar):
+            task_calls.append("called")
+
+        test_task(1, 2)
+
+        self.assertEqual(task_calls, ["called"])
 
 
 class ModelsTest(TembaTest):


### PR DESCRIPTION
Treat expired Redis lock release as expected concurrency behavior instead of
reporting to Sentry. Enable watchdog on sync_classifier_intents to prevent
lock expiry during long runs.

Fixes FLOWS-1X1