### PR TITLE
chore: Remove structured logging from EDA consumers

### DIFF
--- a/WENI-CHANGELOG.md
+++ b/WENI-CHANGELOG.md
@@ -1,3 +1,7 @@
+3.90.4
+----------
+* chore: remove structured logging from EDA consumers
+
 3.90.3
 ----------
 * Avoid get template translations from a inactive channel

--- a/WENI-CHANGELOG.md
+++ b/WENI-CHANGELOG.md
@@ -1,5 +1,6 @@
 3.90.4
 ----------
+* feat: add URN support in multiple languages and update contact templates
 * chore: remove structured logging from EDA consumers
 
 3.90.3

--- a/temba/classifiers/consumers/classifier_consumer.py
+++ b/temba/classifiers/consumers/classifier_consumer.py
@@ -1,25 +1,14 @@
-import logging
-
 from sentry_sdk import capture_exception
 from weni.eda.django.consumers import EDAConsumer
 from weni.eda.messages import Message
 
 from ..usecases.classifier_creation import create_classifier
 
-logger = logging.getLogger(__name__)
-
 
 class ClassifierConsumer(EDAConsumer):
     def consume(self, message: Message):  # pragma: no cover
         try:
-            logger.info("[ClassifierConsumer] Received message")
             body = message.json()
-            logger.info(
-                "[ClassifierConsumer] Processing uuid=%s project_uuid=%s user_email=%s",
-                body.get("uuid"),
-                body.get("project_uuid"),
-                body.get("user_email"),
-            )
             create_classifier(
                 uuid=body.get("uuid"),
                 repository=body.get("repository"),
@@ -30,8 +19,6 @@ class ClassifierConsumer(EDAConsumer):
             )
 
             self.ack()
-            logger.info("[ClassifierConsumer] Message processed successfully uuid=%s", body.get("uuid"))
         except Exception as exception:
-            logger.exception("[ClassifierConsumer] Failed to process message")
             capture_exception(exception)
             raise

--- a/temba/features/consumers/delete_template_integration_consumer.py
+++ b/temba/features/consumers/delete_template_integration_consumer.py
@@ -1,35 +1,20 @@
-import logging
-
 from sentry_sdk import capture_exception
 from weni.eda.django.consumers import EDAConsumer
 from weni.eda.messages import Message
 
 from temba.features.usecases.delete_feature_integration import delete_feature_template
 
-logger = logging.getLogger(__name__)
-
 
 class DeleteFeatureTemplateIntegrationConsumer(EDAConsumer):
     def consume(self, message: Message):  # pragma: no cover
         try:
-            logger.info("[DeleteFeatureTemplateIntegrationConsumer] Received message")
             body = message.json()
-            logger.info(
-                "[DeleteFeatureTemplateIntegrationConsumer] Processing user_email=%s features_flow_count=%s",
-                body.get("user_email"),
-                len(body.get("features_flow") or []),
-            )
             delete_feature_template(
                 features_flow=body.get("features_flow"),
                 user_email=body.get("user_email"),
             )
 
             self.ack()
-            logger.info(
-                "[DeleteFeatureTemplateIntegrationConsumer] Message processed successfully user_email=%s",
-                body.get("user_email"),
-            )
         except Exception as exception:
-            logger.exception("[DeleteFeatureTemplateIntegrationConsumer] Failed to process message")
             capture_exception(exception)
             raise

--- a/temba/features/consumers/feature_template_integration_consumer.py
+++ b/temba/features/consumers/feature_template_integration_consumer.py
@@ -1,25 +1,14 @@
-import logging
-
 from sentry_sdk import capture_exception
 from weni.eda.django.consumers import EDAConsumer
 from weni.eda.messages import Message
 
 from temba.features.usecases.feature_template_integration import integrate_feature_template_consumer
 
-logger = logging.getLogger(__name__)
-
 
 class IntegrateFeatureTemplateConsumer(EDAConsumer):
     def consume(self, message: Message):  # pragma: no cover
         try:
-            logger.info("[IntegrateFeatureTemplateConsumer] Received message")
             body = message.json()
-            logger.info(
-                "[IntegrateFeatureTemplateConsumer] Processing project_uuid=%s feature_uuid=%s user_email=%s",
-                body.get("project_uuid"),
-                body.get("feature_uuid"),
-                body.get("user_email"),
-            )
             integrate_feature_template_consumer(
                 project_uuid=body.get("project_uuid"),
                 feature_uuid=body.get("feature_uuid"),
@@ -30,12 +19,6 @@ class IntegrateFeatureTemplateConsumer(EDAConsumer):
             )
 
             self.ack()
-            logger.info(
-                "[IntegrateFeatureTemplateConsumer] Message processed successfully project_uuid=%s feature_uuid=%s",
-                body.get("project_uuid"),
-                body.get("feature_uuid"),
-            )
         except Exception as exception:
-            logger.exception("[IntegrateFeatureTemplateConsumer] Failed to process message")
             capture_exception(exception)
             raise

--- a/temba/projects/consumers/project_consumer.py
+++ b/temba/projects/consumers/project_consumer.py
@@ -1,5 +1,3 @@
-import logging
-
 from sentry_sdk import capture_exception
 from weni.eda.django.consumers import EDAConsumer
 from weni.eda.messages import Message
@@ -7,8 +5,6 @@ from weni.eda.messages import Message
 from temba.projects.usecases.project_creation import ProjectCreationUseCase
 
 from ..usecases import FlowSetupHandlerUseCase, ProjectCreationDTO, TemplateTypeIntegrationUseCase
-
-logger = logging.getLogger(__name__)
 
 
 class ProjectEventType:
@@ -18,41 +14,17 @@ class ProjectEventType:
 class ProjectConsumer(EDAConsumer):
     def consume(self, message: Message):  # pragma: no cover
         try:
-            logger.info("[ProjectConsumer] Received message")
             event = message.event()
-            logger.info(
-                "[ProjectConsumer] Processing event_type=%s event_id=%s",
-                event.event_type,
-                event.event_id,
-            )
 
             if event.event_type == ProjectEventType.CREATED:
                 self._handle_project_created(event.data)
-            else:
-                logger.warning(
-                    "[ProjectConsumer] Ignoring unsupported event_type=%s event_id=%s",
-                    event.event_type,
-                    event.event_id,
-                )
 
             self.ack()
-            logger.info(
-                "[ProjectConsumer] Message processed successfully event_type=%s event_id=%s",
-                event.event_type,
-                event.event_id,
-            )
         except Exception as exception:
-            logger.exception("[ProjectConsumer] Failed to process message")
             capture_exception(exception)
             raise
 
     def _handle_project_created(self, body: dict):
-        logger.info(
-            "[ProjectConsumer] Processing project uuid=%s name=%s user_email=%s",
-            body.get("uuid"),
-            body.get("name"),
-            body.get("user_email"),
-        )
         project_dto = ProjectCreationDTO(
             uuid=body.get("uuid"),
             name=body.get("name"),

--- a/temba/projects/consumers/project_event_consumer.py
+++ b/temba/projects/consumers/project_event_consumer.py
@@ -1,4 +1,3 @@
-import logging
 from enum import StrEnum
 
 from sentry_sdk import capture_exception
@@ -9,8 +8,6 @@ from temba.projects.usecases.project_delete import delete_project
 from temba.projects.usecases.project_status_update import update_project_status
 from temba.projects.usecases.project_type_update import update_project_type
 from temba.projects.usecases.project_update import update_project_config
-
-logger = logging.getLogger(__name__)
 
 
 class EventAction(StrEnum):
@@ -39,7 +36,6 @@ class ProjectEventConsumer(EDAConsumer):
 
     def consume(self, message: Message):  # pragma: no cover
         try:
-            logger.info("[ProjectEventConsumer] Received message")
             body = message.json()
 
             self._validate_message(body)
@@ -48,23 +44,10 @@ class ProjectEventConsumer(EDAConsumer):
             user_email = body.get("user_email")
             action = body.get("action")
 
-            logger.info(
-                "[ProjectEventConsumer] Processing project_uuid=%s action=%s user_email=%s",
-                project_uuid,
-                action,
-                user_email,
-            )
-
             self._process_event(project_uuid, user_email, action, body)
 
             self.ack()
-            logger.info(
-                "[ProjectEventConsumer] Message processed successfully project_uuid=%s action=%s",
-                project_uuid,
-                action,
-            )
         except Exception as exception:
-            logger.exception("[ProjectEventConsumer] Failed to process message")
             capture_exception(exception)
             raise
 
@@ -104,22 +87,13 @@ class ProjectEventConsumer(EDAConsumer):
             body: Full message body
         """
         if action == EventAction.DELETED:
-            org = delete_project(
+            delete_project(
                 project_uuid=project_uuid,
                 user_email=user_email,
             )
 
-            if org:
-                logger.info(
-                    "[ProjectEventConsumer] Successfully deleted project name=%s project_uuid=%s",
-                    org.name,
-                    project_uuid,
-                )
-            else:
-                logger.info("[ProjectEventConsumer] Project %s not found for deletion", project_uuid)
-
         elif action == EventAction.UPDATED:
-            org = update_project_config(
+            update_project_config(
                 project_uuid=project_uuid,
                 user_email=user_email,
                 name=body.get("name"),
@@ -128,52 +102,20 @@ class ProjectEventConsumer(EDAConsumer):
                 timezone_location=body.get("timezone"),
             )
 
-            if org:
-                logger.info(
-                    "[ProjectEventConsumer] Successfully updated project name=%s project_uuid=%s",
-                    org.name,
-                    project_uuid,
-                )
-            else:
-                logger.info("[ProjectEventConsumer] Project %s not found for update", project_uuid)
-
         elif action == EventAction.STATUS_UPDATED:
             status = body.get("status")
-            org = update_project_status(
+            update_project_status(
                 project_uuid=project_uuid,
                 status=status,
                 user_email=user_email,
             )
 
-            if org:
-                logger.info(
-                    "[ProjectEventConsumer] Successfully updated project name=%s project_uuid=%s "
-                    "status=%s is_suspended=%s",
-                    org.name,
-                    project_uuid,
-                    status,
-                    org.is_suspended,
-                )
-            else:
-                logger.info("[ProjectEventConsumer] Project %s not found for status update", project_uuid)
-
         elif action == EventAction.PROJECT_TYPE_UPDATED:
             is_multi_agents = bool(body.get("is_multi_agents"))
-            org = update_project_type(
+            update_project_type(
                 project_uuid=project_uuid,
                 is_multi_agents=is_multi_agents,
                 user_email=user_email,
             )
-
-            if org:
-                logger.info(
-                    "[ProjectEventConsumer] Successfully updated project name=%s project_uuid=%s "
-                    "is_multi_agents=%s",
-                    org.name,
-                    project_uuid,
-                    is_multi_agents,
-                )
-            else:
-                logger.info("[ProjectEventConsumer] Project %s not found for project type update", project_uuid)
         else:
             raise ValueError(f"Unknown action: {action}")

--- a/temba/projects/consumers/template_type_consumer.py
+++ b/temba/projects/consumers/template_type_consumer.py
@@ -1,30 +1,17 @@
-import logging
-
 from sentry_sdk import capture_exception
 from weni.eda.django.consumers import EDAConsumer
 from weni.eda.messages import Message
 
 from temba.projects.usecases.template_type_creation import create_template_type
 
-logger = logging.getLogger(__name__)
-
 
 class TemplateTypeConsumer(EDAConsumer):
     def consume(self, message: Message):  # pragma: no cover
         try:
-            logger.info("[TemplateTypeConsumer] Received message")
             body = message.json()
-            logger.info(
-                "[TemplateTypeConsumer] Processing uuid=%s name=%s project_uuid=%s",
-                body.get("uuid"),
-                body.get("name"),
-                body.get("project_uuid"),
-            )
             create_template_type(uuid=body.get("uuid"), name=body.get("name"), project_uuid=body.get("project_uuid"))
 
             self.ack()
-            logger.info("[TemplateTypeConsumer] Message processed successfully uuid=%s", body.get("uuid"))
         except Exception as exception:
-            logger.exception("[TemplateTypeConsumer] Failed to process message")
             capture_exception(exception)
             raise

--- a/temba/projects/consumers/tests/test_project_event_consumer.py
+++ b/temba/projects/consumers/tests/test_project_event_consumer.py
@@ -65,7 +65,7 @@ class TestProjectEventConsumer(TembaTest):
         self.assertEqual(reloaded_org.timezone, pytz.timezone("America/Sao_Paulo"))
 
     def test_consume_update_action_when_usecase_returns_none_acknowledges(self):
-        """update_project_config may return None; consumer acks and logs not found."""
+        """update_project_config may return None; consumer still acks."""
         body = {
             "project_uuid": self.project_uuid,
             "user_email": self.user.email,
@@ -161,7 +161,7 @@ class TestProjectEventConsumer(TembaTest):
         self.assertTrue(reloaded_org.config.get("is_multi_agents"))
 
     def test_consume_project_type_update_when_usecase_returns_none_acknowledges(self):
-        """update_project_type may return None; consumer acks and logs not found."""
+        """update_project_type may return None; consumer still acks."""
         body = {
             "project_uuid": self.project_uuid,
             "user_email": self.user.email,

--- a/temba/projects/consumers/update_brain_on_consumer.py
+++ b/temba/projects/consumers/update_brain_on_consumer.py
@@ -1,25 +1,14 @@
-import logging
-
 from sentry_sdk import capture_exception
 from weni.eda.django.consumers import EDAConsumer
 from weni.eda.messages import Message
 
 from temba.projects.usecases.update_brain_on import update_project_brain_on
 
-logger = logging.getLogger(__name__)
-
 
 class UpdateBrainOnConsumer(EDAConsumer):
     def consume(self, message: Message):  # pragma: no cover
         try:
-            logger.info("[UpdateBrainOnConsumer] Received message")
             body = message.json()
-            logger.info(
-                "[UpdateBrainOnConsumer] Processing project_uuid=%s brain_on=%s user_email=%s",
-                body.get("project_uuid"),
-                body.get("brain_on"),
-                body.get("user"),
-            )
             update_project_brain_on(
                 project_uuid=body.get("project_uuid"),
                 brain_on=body.get("brain_on"),
@@ -27,11 +16,6 @@ class UpdateBrainOnConsumer(EDAConsumer):
             )
 
             self.ack()
-            logger.info(
-                "[UpdateBrainOnConsumer] Message processed successfully project_uuid=%s",
-                body.get("project_uuid"),
-            )
         except Exception as exception:
-            logger.exception("[UpdateBrainOnConsumer] Failed to process message")
             capture_exception(exception)
             raise

--- a/temba/projects/consumers/update_permission_consumer.py
+++ b/temba/projects/consumers/update_permission_consumer.py
@@ -1,27 +1,14 @@
-import logging
-
 from sentry_sdk import capture_exception
 from weni.eda.django.consumers import EDAConsumer
 from weni.eda.messages import Message
 
 from temba.projects.usecases.permission_update import update_permission
 
-logger = logging.getLogger(__name__)
-
 
 class UpdatePermissionConsumer(EDAConsumer):
     def consume(self, message: Message):  # pragma: no cover
         try:
-            logger.info("[UpdatePermissionConsumer] Received message")
             body = message.json()
-
-            logger.info(
-                "[UpdatePermissionConsumer] Processing project_uuid=%s action=%s user_email=%s role=%s",
-                body.get("project"),
-                body.get("action"),
-                body.get("user"),
-                body.get("role"),
-            )
 
             update_permission(
                 project_uuid=body.get("project"),  # project_uuid
@@ -31,12 +18,6 @@ class UpdatePermissionConsumer(EDAConsumer):
             )
 
             self.ack()
-            logger.info(
-                "[UpdatePermissionConsumer] Message processed successfully project_uuid=%s action=%s",
-                body.get("project"),
-                body.get("action"),
-            )
         except Exception as exception:
-            logger.exception("[UpdatePermissionConsumer] Failed to process message")
             capture_exception(exception)
             raise

--- a/temba/settings.py.prod
+++ b/temba/settings.py.prod
@@ -260,10 +260,6 @@ sentry_sdk.init(dsn=env("SENTRY_DSN", default=""), integrations=[DjangoIntegrati
 
 # LOGGING
 # ------------------------------------------------------------------------------
-# Controls INFO/DEBUG logs from EDA consumers (temba.*.consumers) and weni.eda.
-# Examples: CONSUMERS_LOG_LEVEL=INFO | WARNING | DEBUG | ERROR
-CONSUMERS_LOG_LEVEL = env("CONSUMERS_LOG_LEVEL", default="WARNING")
-
 LOGGING = {
     "version": 1,
     "disable_existing_loggers": env("DISABLE_LOG", default=True),
@@ -284,13 +280,6 @@ LOGGING = {
         # OIDC
         "mozilla_django_oidc": {"level": "DEBUG", "handlers": ["console"], "propagate": False},
         "weni_django_oidc": {"level": "DEBUG", "handlers": ["console"], "propagate": False},
-        # EDA consumers
-        "temba.projects.consumers": {"level": CONSUMERS_LOG_LEVEL, "handlers": ["console"], "propagate": False},
-        "temba.classifiers.consumers": {"level": CONSUMERS_LOG_LEVEL, "handlers": ["console"], "propagate": False},
-        "temba.tickets.consumers": {"level": CONSUMERS_LOG_LEVEL, "handlers": ["console"], "propagate": False},
-        "temba.features.consumers": {"level": CONSUMERS_LOG_LEVEL, "handlers": ["console"], "propagate": False},
-        "temba.templates.consumers": {"level": CONSUMERS_LOG_LEVEL, "handlers": ["console"], "propagate": False},
-        "weni.eda": {"level": CONSUMERS_LOG_LEVEL, "handlers": ["console"], "propagate": False},
     },
 }
 
@@ -445,9 +434,7 @@ OLD_DESIGN_EXCLUDED_CHANNELS_CODES = env.list("OLD_DESIGN_EXCLUDED_CHANNELS_CODE
 # ------------------------------------------------------------------------------------------
 DISABLE_OIDC = env.bool("DISABLE_OIDC", default=False)
 if DISABLE_OIDC:
-    REST_FRAMEWORK["DEFAULT_AUTHENTICATION_CLASSES"].remove(
-        "mozilla_django_oidc.contrib.drf.OIDCAuthentication"
-    )
+    REST_FRAMEWORK["DEFAULT_AUTHENTICATION_CLASSES"].remove("mozilla_django_oidc.contrib.drf.OIDCAuthentication")
 
     installed_apps_list = list(INSTALLED_APPS)
     installed_apps_list.remove("mozilla_django_oidc")
@@ -466,7 +453,7 @@ if DISABLE_OIDC:
 CONNECT_BASE_URL = env("CONNECT_BASE_URL", default="https://api.dev.cloud.weni.ai")
 
 # ----------------------------------------------------------------------------------------
-# Option to enable redirect all routes (except api), to redirect view 
+# Option to enable redirect all routes (except api), to redirect view
 # ----------------------------------------------------------------------------------------
 WENI_REDIRECT_DEPRECATED_DOMAIN = env.bool("WENI_REDIRECT_DEPRECATED_DOMAIN", default=False)
 if WENI_REDIRECT_DEPRECATED_DOMAIN:
@@ -524,4 +511,6 @@ MUTABLE_EDITOR_DOMAINS = env.tuple("MUTABLE_EDITOR_DOMAINS", default=("@inspiria
 LAMBDA_ALLOWED_ROLES = env.list("LAMBDA_ALLOWED_ROLES", default=[])
 
 # Lambda permitted urls
-LAMBDA_VALIDATION_URL = env.list("LAMBDA_VALIDATION_URL", default=["https://sts.amazonaws.com/?Action=GetCallerIdentity&"])
+LAMBDA_VALIDATION_URL = env.list(
+    "LAMBDA_VALIDATION_URL", default=["https://sts.amazonaws.com/?Action=GetCallerIdentity&"]
+)

--- a/temba/templates/consumers/message_template_consumer.py
+++ b/temba/templates/consumers/message_template_consumer.py
@@ -1,4 +1,3 @@
-import logging
 from dataclasses import asdict, dataclass
 
 from sentry_sdk import capture_exception
@@ -6,8 +5,6 @@ from weni.eda.django.consumers import EDAConsumer
 from weni.eda.messages import Message
 from weni_datalake_sdk.clients.client import send_message_template_data_async
 from weni_datalake_sdk.paths.message_template_path import MessageTemplatePath
-
-logger = logging.getLogger(__name__)
 
 
 @dataclass
@@ -28,14 +25,7 @@ class MessageTemplateDTO:  # pragma: no cover
 class MessageTemplateConsumer(EDAConsumer):  # pragma: no cover
     def consume(self, message: Message):
         try:
-            logger.info("[MessageTemplateConsumer] Received message")
             body = message.json()
-            logger.info(
-                "[MessageTemplateConsumer] Processing message_id=%s template_uuid=%s channel=%s",
-                body.get("message_id"),
-                body.get("template_uuid"),
-                body.get("channel_uuid"),
-            )
             message_template_dto = MessageTemplateDTO(
                 contact_urn=body.get("contact_urn"),
                 channel=body.get("channel_uuid"),
@@ -53,11 +43,6 @@ class MessageTemplateConsumer(EDAConsumer):  # pragma: no cover
             send_message_template_data_async(MessageTemplatePath, asdict(message_template_dto))
 
             self.ack()
-            logger.info(
-                "[MessageTemplateConsumer] Message processed successfully message_id=%s",
-                body.get("message_id"),
-            )
         except Exception as exception:
-            logger.exception("[MessageTemplateConsumer] Failed to process message")
             capture_exception(exception)
             raise

--- a/temba/templates/consumers/message_template_webhook.py
+++ b/temba/templates/consumers/message_template_webhook.py
@@ -1,4 +1,3 @@
-import logging
 from dataclasses import asdict, dataclass
 
 from sentry_sdk import capture_exception
@@ -6,8 +5,6 @@ from weni.eda.django.consumers import EDAConsumer
 from weni.eda.messages import Message
 from weni_datalake_sdk.clients.client import send_message_template_status_data_async
 from weni_datalake_sdk.paths.message_template_status_path import MessageTemplateStatusPath
-
-logger = logging.getLogger(__name__)
 
 
 @dataclass
@@ -23,14 +20,7 @@ class MessageTemplateWebhookDTO:  # pragma: no cover
 class MessageTemplateWebhookConsumer(EDAConsumer):
     def consume(self, message: Message):  # pragma: no cover
         try:
-            logger.info("[MessageTemplateWebhookConsumer] Received message")
             body = message.json()
-            logger.info(
-                "[MessageTemplateWebhookConsumer] Processing message_id=%s status=%s channel=%s",
-                body.get("message_id"),
-                body.get("status"),
-                body.get("channel_uuid"),
-            )
             message_template_webhook_dto = MessageTemplateWebhookDTO(
                 contact_urn=body.get("contact_urn"),
                 status=body.get("status"),
@@ -43,11 +33,6 @@ class MessageTemplateWebhookConsumer(EDAConsumer):
             send_message_template_status_data_async(MessageTemplateStatusPath, asdict(message_template_webhook_dto))
 
             self.ack()
-            logger.info(
-                "[MessageTemplateWebhookConsumer] Message processed successfully message_id=%s",
-                body.get("message_id"),
-            )
         except Exception as exception:
-            logger.exception("[MessageTemplateWebhookConsumer] Failed to process message")
             capture_exception(exception)
             raise

--- a/temba/tickets/consumers/ticketer_consumer.py
+++ b/temba/tickets/consumers/ticketer_consumer.py
@@ -1,25 +1,14 @@
-import logging
-
 from sentry_sdk import capture_exception
 from weni.eda.django.consumers import EDAConsumer
 from weni.eda.messages import Message
 
 from ..usecases.ticketer_creation import create_ticketer
 
-logger = logging.getLogger(__name__)
-
 
 class TicketConsumer(EDAConsumer):
     def consume(self, message: Message):  # pragma: no cover
         try:
-            logger.info("[TicketConsumer] Received message")
             body = message.json()
-            logger.info(
-                "[TicketConsumer] Processing uuid=%s project_uuid=%s user_email=%s",
-                body.get("uuid"),
-                body.get("project_uuid"),
-                body.get("user_email"),
-            )
             create_ticketer(
                 uuid=body.get("uuid"),
                 name=body.get("name"),
@@ -30,8 +19,6 @@ class TicketConsumer(EDAConsumer):
             )
 
             self.ack()
-            logger.info("[TicketConsumer] Message processed successfully uuid=%s", body.get("uuid"))
         except Exception as exception:
-            logger.exception("[TicketConsumer] Failed to process message")
             capture_exception(exception)
             raise


### PR DESCRIPTION
## What

- Remove received/processing/success/failure logging from all EDA consumers
- Remove `CONSUMERS_LOG_LEVEL` and related logger config from production settings
- Keep Sentry error capture via `capture_exception`

## Why

The verbose consumer logs added in #812 generate unnecessary noise in production. Error reporting remains covered by Sentry.