### PR TITLE
feat: enhance CtwaReferralSource model with org field and backfill functionality

### DIFF
--- a/temba/conversion_events/migrations/0003_ctwareferralsource_org.py
+++ b/temba/conversion_events/migrations/0003_ctwareferralsource_org.py
@@ -35,8 +35,6 @@ class Migration(migrations.Migration):
         ),
         migrations.AddIndex(
             model_name="ctwareferralsource",
-            index=models.Index(
-                fields=["org", "-last_seen_at"], name="idx_ctwa_ref_src_org_last_seen"
-            ),
+            index=models.Index(fields=["org", "-last_seen_at"], name="idx_ctwa_ref_src_org_last_seen"),
         ),
     ]

--- a/temba/conversion_events/migrations/0003_ctwareferralsource_org.py
+++ b/temba/conversion_events/migrations/0003_ctwareferralsource_org.py
@@ -1,0 +1,42 @@
+# Generated manually: add nullable org to CtwaReferralSource (schema only)
+
+import django.db.models.deletion
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("conversion_events", "0002_ctwa_referral_sources"),
+        ("orgs", "0094_unique_contact_count"),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name="ctwareferralsource",
+            name="org",
+            field=models.ForeignKey(
+                null=True,
+                on_delete=django.db.models.deletion.PROTECT,
+                related_name="ctwa_referral_sources",
+                to="orgs.org",
+            ),
+        ),
+        migrations.RemoveConstraint(
+            model_name="ctwareferralsource",
+            name="uq_ctwa_referral_source",
+        ),
+        migrations.AddConstraint(
+            model_name="ctwareferralsource",
+            constraint=models.UniqueConstraint(
+                fields=("org", "source_id", "source_type"),
+                name="uq_ctwa_referral_source",
+            ),
+        ),
+        migrations.AddIndex(
+            model_name="ctwareferralsource",
+            index=models.Index(
+                fields=["org", "-last_seen_at"], name="idx_ctwa_ref_src_org_last_seen"
+            ),
+        ),
+    ]

--- a/temba/conversion_events/migrations/0004_backfill_ctwareferralsource_org.py
+++ b/temba/conversion_events/migrations/0004_backfill_ctwareferralsource_org.py
@@ -65,6 +65,43 @@ def apply_orgs_to_source(source, channels_by_org, CtwaReferralSource, CTWA):
         )
 
 
+def resolve_batch_orgs(batch, org_map, CtwaReferralSource, CTWA):
+    """Attribute each source in the batch, returning the ids that stayed unresolved."""
+    unresolved_ids = []
+    for source in batch:
+        channels_by_org = org_map.get(source.id, {})
+        if not channels_by_org:
+            logger.warning(
+                f"Could not resolve org for CtwaReferralSource id={source.id} "
+                f"source_id={source.source_id} source_type={source.source_type}"
+            )
+            if source.org_id is None:
+                unresolved_ids.append(source.id)
+            continue
+        if source.org_id is not None and source.org_id not in channels_by_org:
+            logger.warning(
+                f"CtwaReferralSource id={source.id} has org_id={source.org_id} "
+                f"but its CTWAs resolve to org_ids={list(channels_by_org)}"
+            )
+        apply_orgs_to_source(source, channels_by_org, CtwaReferralSource, CTWA)
+    return unresolved_ids
+
+
+def delete_unresolved_sources(source_ids, CtwaReferralSource, CTWA):
+    """Drop sources that map to no org, together with their CTWAs.
+
+    0005 makes org NOT NULL, so rows left with a null org would break it. Their
+    events are already unusable: attribution needs an existing channel with an org.
+    CTWAs are deleted first because they protect the source.
+    """
+    if not source_ids:
+        return
+
+    logger.warning(f"Deleting CtwaReferralSource rows with no resolvable org: {source_ids}")
+    CTWA.objects.filter(referral_source_id__in=source_ids).delete()
+    CtwaReferralSource.objects.filter(id__in=source_ids).delete()
+
+
 def backfill_ctwa_referral_source_org(CtwaReferralSource, CTWA, Channel, batch_size=BATCH_SIZE, source_ids=None):
     max_id = 0
     while True:
@@ -80,20 +117,8 @@ def backfill_ctwa_referral_source_org(CtwaReferralSource, CTWA, Channel, batch_s
 
         with transaction.atomic():
             org_map = org_channels_by_source_id([source.id for source in batch], CTWA, Channel)
-            for source in batch:
-                channels_by_org = org_map.get(source.id, {})
-                if not channels_by_org:
-                    logger.warning(
-                        f"Could not resolve org for CtwaReferralSource id={source.id} "
-                        f"source_id={source.source_id} source_type={source.source_type}"
-                    )
-                    continue
-                if source.org_id is not None and source.org_id not in channels_by_org:
-                    logger.warning(
-                        f"CtwaReferralSource id={source.id} has org_id={source.org_id} "
-                        f"but its CTWAs resolve to org_ids={list(channels_by_org)}"
-                    )
-                apply_orgs_to_source(source, channels_by_org, CtwaReferralSource, CTWA)
+            unresolved_ids = resolve_batch_orgs(batch, org_map, CtwaReferralSource, CTWA)
+            delete_unresolved_sources(unresolved_ids, CtwaReferralSource, CTWA)
 
         max_id = batch[-1].id
 

--- a/temba/conversion_events/migrations/0004_backfill_ctwareferralsource_org.py
+++ b/temba/conversion_events/migrations/0004_backfill_ctwareferralsource_org.py
@@ -21,9 +21,9 @@ def org_ids_by_source_id(source_ids, CTWA, Channel):
     channel_uuids = {str(channel_uuid) for _, channel_uuid in ctwa_rows}
     org_by_channel = {
         str(uuid): org_id
-        for uuid, org_id in Channel.objects.filter(
-            uuid__in=channel_uuids, org_id__isnull=False
-        ).values_list("uuid", "org_id")
+        for uuid, org_id in Channel.objects.filter(uuid__in=channel_uuids, org_id__isnull=False).values_list(
+            "uuid", "org_id"
+        )
     }
 
     orgs = defaultdict(set)
@@ -57,17 +57,13 @@ def apply_orgs_to_source(source, org_ids, CtwaReferralSource, CTWA, Channel):
             },
         )
 
-        channel_uuids = list(
-            Channel.objects.filter(org_id=extra_org_id).values_list("uuid", flat=True)
+        channel_uuids = list(Channel.objects.filter(org_id=extra_org_id).values_list("uuid", flat=True))
+        CTWA.objects.filter(referral_source_id=source.id, channel_uuid__in=channel_uuids).update(
+            referral_source_id=clone.id
         )
-        CTWA.objects.filter(
-            referral_source_id=source.id, channel_uuid__in=channel_uuids
-        ).update(referral_source_id=clone.id)
 
 
-def backfill_ctwa_referral_source_org(
-    CtwaReferralSource, CTWA, Channel, batch_size=BATCH_SIZE, source_ids=None
-):
+def backfill_ctwa_referral_source_org(CtwaReferralSource, CTWA, Channel, batch_size=BATCH_SIZE, source_ids=None):
     max_id = 0
     while True:
         queryset = CtwaReferralSource.objects.filter(id__gt=max_id).order_by("id")
@@ -81,9 +77,7 @@ def backfill_ctwa_referral_source_org(
             break
 
         with transaction.atomic():
-            org_map = org_ids_by_source_id(
-                [source.id for source in batch], CTWA, Channel
-            )
+            org_map = org_ids_by_source_id([source.id for source in batch], CTWA, Channel)
             for source in batch:
                 org_ids = org_map.get(source.id, [])
                 if not org_ids:

--- a/temba/conversion_events/migrations/0004_backfill_ctwareferralsource_org.py
+++ b/temba/conversion_events/migrations/0004_backfill_ctwareferralsource_org.py
@@ -1,0 +1,118 @@
+# Generated manually: backfill CtwaReferralSource.org from CTWA channels
+
+import logging
+from collections import defaultdict
+
+from django.db import migrations, transaction
+
+logger = logging.getLogger(__name__)
+
+BATCH_SIZE = 1000
+
+
+def org_ids_by_source_id(source_ids, CTWA, Channel):
+    """Map each referral source id to the distinct org ids of its CTWA channels."""
+    if not source_ids:
+        return {}
+
+    ctwa_rows = CTWA.objects.filter(referral_source_id__in=source_ids).values_list(
+        "referral_source_id", "channel_uuid"
+    )
+    channel_uuids = {str(channel_uuid) for _, channel_uuid in ctwa_rows}
+    org_by_channel = {
+        str(uuid): org_id
+        for uuid, org_id in Channel.objects.filter(
+            uuid__in=channel_uuids, org_id__isnull=False
+        ).values_list("uuid", "org_id")
+    }
+
+    orgs = defaultdict(set)
+    for source_id, channel_uuid in ctwa_rows:
+        org_id = org_by_channel.get(str(channel_uuid))
+        if org_id is not None:
+            orgs[source_id].add(org_id)
+
+    return {source_id: sorted(org_id_set) for source_id, org_id_set in orgs.items()}
+
+
+def apply_orgs_to_source(source, org_ids, CtwaReferralSource, CTWA, Channel):
+    """Assign the first org to source and clone it for each extra org, retargeting CTWAs."""
+    if not org_ids:
+        return
+
+    first_org_id, *extra_org_ids = org_ids
+    if source.org_id != first_org_id:
+        CtwaReferralSource.objects.filter(id=source.id).update(org_id=first_org_id)
+        source.org_id = first_org_id
+
+    for extra_org_id in extra_org_ids:
+        clone, _ = CtwaReferralSource.objects.get_or_create(
+            org_id=extra_org_id,
+            source_id=source.source_id,
+            source_type=source.source_type,
+            defaults={
+                "source_url": source.source_url,
+                "headline": source.headline,
+                "body": source.body,
+            },
+        )
+
+        channel_uuids = list(
+            Channel.objects.filter(org_id=extra_org_id).values_list("uuid", flat=True)
+        )
+        CTWA.objects.filter(
+            referral_source_id=source.id, channel_uuid__in=channel_uuids
+        ).update(referral_source_id=clone.id)
+
+
+def backfill_ctwa_referral_source_org(
+    CtwaReferralSource, CTWA, Channel, batch_size=BATCH_SIZE, source_ids=None
+):
+    max_id = 0
+    while True:
+        queryset = CtwaReferralSource.objects.filter(id__gt=max_id).order_by("id")
+        if source_ids is not None:
+            queryset = queryset.filter(id__in=source_ids)
+        else:
+            queryset = queryset.filter(org_id__isnull=True)
+
+        batch = list(queryset[:batch_size])
+        if not batch:
+            break
+
+        with transaction.atomic():
+            org_map = org_ids_by_source_id(
+                [source.id for source in batch], CTWA, Channel
+            )
+            for source in batch:
+                org_ids = org_map.get(source.id, [])
+                if not org_ids:
+                    logger.warning(
+                        f"Could not resolve org for CtwaReferralSource id={source.id} "
+                        f"source_id={source.source_id} source_type={source.source_type}"
+                    )
+                    continue
+                apply_orgs_to_source(source, org_ids, CtwaReferralSource, CTWA, Channel)
+
+        max_id = batch[-1].id
+
+
+def forwards(apps, schema_editor):
+    CtwaReferralSource = apps.get_model("conversion_events", "CtwaReferralSource")
+    CTWA = apps.get_model("conversion_events", "CTWA")
+    Channel = apps.get_model("channels", "Channel")
+    backfill_ctwa_referral_source_org(CtwaReferralSource, CTWA, Channel)
+
+
+class Migration(migrations.Migration):
+
+    atomic = False
+
+    dependencies = [
+        ("conversion_events", "0003_ctwareferralsource_org"),
+        ("channels", "0137_alter_channel_name"),
+    ]
+
+    operations = [
+        migrations.RunPython(forwards, migrations.RunPython.noop),
+    ]

--- a/temba/conversion_events/migrations/0004_backfill_ctwareferralsource_org.py
+++ b/temba/conversion_events/migrations/0004_backfill_ctwareferralsource_org.py
@@ -10,8 +10,8 @@ logger = logging.getLogger(__name__)
 BATCH_SIZE = 1000
 
 
-def org_ids_by_source_id(source_ids, CTWA, Channel):
-    """Map each referral source id to the distinct org ids of its CTWA channels."""
+def org_channels_by_source_id(source_ids, CTWA, Channel):
+    """Map each referral source id to {org_id: [channel_uuid, ...]} of its CTWA channels."""
     if not source_ids:
         return {}
 
@@ -26,28 +26,32 @@ def org_ids_by_source_id(source_ids, CTWA, Channel):
         )
     }
 
-    orgs = defaultdict(set)
+    channels_by_source_org = defaultdict(lambda: defaultdict(list))
     for source_id, channel_uuid in ctwa_rows:
         org_id = org_by_channel.get(str(channel_uuid))
         if org_id is not None:
-            orgs[source_id].add(org_id)
+            channels_by_source_org[source_id][org_id].append(channel_uuid)
 
-    return {source_id: sorted(org_id_set) for source_id, org_id_set in orgs.items()}
+    return {
+        source_id: dict(sorted(org_channels.items())) for source_id, org_channels in channels_by_source_org.items()
+    }
 
 
-def apply_orgs_to_source(source, org_ids, CtwaReferralSource, CTWA, Channel):
-    """Assign the first org to source and clone it for each extra org, retargeting CTWAs."""
-    if not org_ids:
+def apply_orgs_to_source(source, channels_by_org, CtwaReferralSource, CTWA):
+    """Assign the anchor org to source and clone it for each extra org, retargeting CTWAs."""
+    if not channels_by_org:
         return
 
-    first_org_id, *extra_org_ids = org_ids
-    if source.org_id != first_org_id:
-        CtwaReferralSource.objects.filter(id=source.id).update(org_id=first_org_id)
-        source.org_id = first_org_id
+    anchor_org_id = source.org_id or next(iter(channels_by_org))
+    if source.org_id != anchor_org_id:
+        CtwaReferralSource.objects.filter(id=source.id).update(org_id=anchor_org_id)
+        source.org_id = anchor_org_id
 
-    for extra_org_id in extra_org_ids:
+    for org_id, channel_uuids in channels_by_org.items():
+        if org_id == anchor_org_id:
+            continue
         clone, _ = CtwaReferralSource.objects.get_or_create(
-            org_id=extra_org_id,
+            org_id=org_id,
             source_id=source.source_id,
             source_type=source.source_type,
             defaults={
@@ -56,8 +60,6 @@ def apply_orgs_to_source(source, org_ids, CtwaReferralSource, CTWA, Channel):
                 "body": source.body,
             },
         )
-
-        channel_uuids = list(Channel.objects.filter(org_id=extra_org_id).values_list("uuid", flat=True))
         CTWA.objects.filter(referral_source_id=source.id, channel_uuid__in=channel_uuids).update(
             referral_source_id=clone.id
         )
@@ -77,16 +79,21 @@ def backfill_ctwa_referral_source_org(CtwaReferralSource, CTWA, Channel, batch_s
             break
 
         with transaction.atomic():
-            org_map = org_ids_by_source_id([source.id for source in batch], CTWA, Channel)
+            org_map = org_channels_by_source_id([source.id for source in batch], CTWA, Channel)
             for source in batch:
-                org_ids = org_map.get(source.id, [])
-                if not org_ids:
+                channels_by_org = org_map.get(source.id, {})
+                if not channels_by_org:
                     logger.warning(
                         f"Could not resolve org for CtwaReferralSource id={source.id} "
                         f"source_id={source.source_id} source_type={source.source_type}"
                     )
                     continue
-                apply_orgs_to_source(source, org_ids, CtwaReferralSource, CTWA, Channel)
+                if source.org_id is not None and source.org_id not in channels_by_org:
+                    logger.warning(
+                        f"CtwaReferralSource id={source.id} has org_id={source.org_id} "
+                        f"but its CTWAs resolve to org_ids={list(channels_by_org)}"
+                    )
+                apply_orgs_to_source(source, channels_by_org, CtwaReferralSource, CTWA)
 
         max_id = batch[-1].id
 

--- a/temba/conversion_events/migrations/0005_ctwareferralsource_org_not_null.py
+++ b/temba/conversion_events/migrations/0005_ctwareferralsource_org_not_null.py
@@ -1,0 +1,24 @@
+# Generated manually: require CtwaReferralSource.org after backfill
+
+import django.db.models.deletion
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("conversion_events", "0004_backfill_ctwareferralsource_org"),
+        ("orgs", "0094_unique_contact_count"),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name="ctwareferralsource",
+            name="org",
+            field=models.ForeignKey(
+                on_delete=django.db.models.deletion.PROTECT,
+                related_name="ctwa_referral_sources",
+                to="orgs.org",
+            ),
+        ),
+    ]

--- a/temba/conversion_events/models.py
+++ b/temba/conversion_events/models.py
@@ -15,9 +15,7 @@ class CtwaReferralSource(models.Model):
         (SOURCE_TYPE_POST, "Post"),
     )
 
-    org = models.ForeignKey(
-        Org, on_delete=models.PROTECT, related_name="ctwa_referral_sources"
-    )
+    org = models.ForeignKey(Org, on_delete=models.PROTECT, related_name="ctwa_referral_sources")
     source_id = models.CharField(max_length=64)
     source_type = models.CharField(max_length=16, choices=SOURCE_TYPE_CHOICES)
     source_url = models.TextField(null=True, blank=True)
@@ -43,9 +41,7 @@ class CtwaReferralSource(models.Model):
         indexes = [
             models.Index(fields=["source_id"], name="idx_ctwa_ref_src_source_id"),
             models.Index(fields=["-last_seen_at"], name="idx_ctwa_ref_src_last_seen"),
-            models.Index(
-                fields=["org", "-last_seen_at"], name="idx_ctwa_ref_src_org_last_seen"
-            ),
+            models.Index(fields=["org", "-last_seen_at"], name="idx_ctwa_ref_src_org_last_seen"),
         ]
 
     def __str__(self):
@@ -91,9 +87,7 @@ class CTWA(models.Model):
         related_name="conversion_events",
         db_column="referral_source_id",
     )
-    message_id = models.CharField(
-        max_length=255, null=True, blank=True, help_text="WhatsApp message ID (wamid)"
-    )
+    message_id = models.CharField(max_length=255, null=True, blank=True, help_text="WhatsApp message ID (wamid)")
     created_at = models.DateTimeField(auto_now_add=True)
 
     class Meta:

--- a/temba/conversion_events/models.py
+++ b/temba/conversion_events/models.py
@@ -1,5 +1,7 @@
 from django.db import models
 
+from temba.orgs.models import Org
+
 
 class CtwaReferralSource(models.Model):
     """
@@ -13,6 +15,9 @@ class CtwaReferralSource(models.Model):
         (SOURCE_TYPE_POST, "Post"),
     )
 
+    org = models.ForeignKey(
+        Org, on_delete=models.PROTECT, related_name="ctwa_referral_sources"
+    )
     source_id = models.CharField(max_length=64)
     source_type = models.CharField(max_length=16, choices=SOURCE_TYPE_CHOICES)
     source_url = models.TextField(null=True, blank=True)
@@ -26,7 +31,10 @@ class CtwaReferralSource(models.Model):
     class Meta:
         db_table = "ctwa_referral_sources"
         constraints = [
-            models.UniqueConstraint(fields=["source_id", "source_type"], name="uq_ctwa_referral_source"),
+            models.UniqueConstraint(
+                fields=["org", "source_id", "source_type"],
+                name="uq_ctwa_referral_source",
+            ),
             models.CheckConstraint(
                 check=models.Q(source_type__in=["ad", "post"]),
                 name="chk_ctwa_referral_source_type",
@@ -35,10 +43,24 @@ class CtwaReferralSource(models.Model):
         indexes = [
             models.Index(fields=["source_id"], name="idx_ctwa_ref_src_source_id"),
             models.Index(fields=["-last_seen_at"], name="idx_ctwa_ref_src_last_seen"),
+            models.Index(
+                fields=["org", "-last_seen_at"], name="idx_ctwa_ref_src_org_last_seen"
+            ),
         ]
 
     def __str__(self):
         return f"CTWA Referral Source - {self.source_type}:{self.source_id}"
+
+    @classmethod
+    def get_or_create_for_org(cls, org, source_id, source_type, **defaults):
+        if org is None:
+            raise ValueError("org is required to create a CtwaReferralSource")
+        return cls.objects.get_or_create(
+            org=org,
+            source_id=source_id,
+            source_type=source_type,
+            defaults=defaults,
+        )
 
 
 class CTWA(models.Model):
@@ -58,7 +80,10 @@ class CTWA(models.Model):
     channel_uuid = models.UUIDField(help_text="Channel UUID")
     waba = models.CharField(max_length=255, help_text="WhatsApp Business Account ID")
     phone_number_id = models.CharField(
-        max_length=64, null=True, blank=True, help_text="Phone number ID from webhook metadata"
+        max_length=64,
+        null=True,
+        blank=True,
+        help_text="Phone number ID from webhook metadata",
     )
     referral_source = models.ForeignKey(
         CtwaReferralSource,
@@ -66,7 +91,9 @@ class CTWA(models.Model):
         related_name="conversion_events",
         db_column="referral_source_id",
     )
-    message_id = models.CharField(max_length=255, null=True, blank=True, help_text="WhatsApp message ID (wamid)")
+    message_id = models.CharField(
+        max_length=255, null=True, blank=True, help_text="WhatsApp message ID (wamid)"
+    )
     created_at = models.DateTimeField(auto_now_add=True)
 
     class Meta:

--- a/temba/conversion_events/tests.py
+++ b/temba/conversion_events/tests.py
@@ -1,7 +1,7 @@
 import json
+from datetime import datetime, timezone as dt_timezone
 from importlib import import_module
 from types import SimpleNamespace
-from datetime import datetime, timezone as dt_timezone
 from unittest.mock import Mock, patch
 from uuid import uuid4
 

--- a/temba/conversion_events/tests.py
+++ b/temba/conversion_events/tests.py
@@ -20,9 +20,7 @@ from temba.conversion_events.models import CTWA, CtwaReferralSource
 from temba.conversion_events.serializers import ConversionEventSerializer
 from temba.tests import TembaTest
 
-_backfill = import_module(
-    "temba.conversion_events.migrations.0004_backfill_ctwareferralsource_org"
-)
+_backfill = import_module("temba.conversion_events.migrations.0004_backfill_ctwareferralsource_org")
 apply_orgs_to_source = _backfill.apply_orgs_to_source
 backfill_ctwa_referral_source_org = _backfill.backfill_ctwa_referral_source_org
 org_ids_by_source_id = _backfill.org_ids_by_source_id
@@ -37,16 +35,10 @@ def create_test_ctwa(**kwargs):
         if org is None:
             channel_uuid = kwargs.get("channel_uuid")
             if channel_uuid is not None:
-                channel = (
-                    Channel.objects.filter(uuid=str(channel_uuid))
-                    .select_related("org")
-                    .first()
-                )
+                channel = Channel.objects.filter(uuid=str(channel_uuid)).select_related("org").first()
                 if channel is not None:
                     org = channel.org
-        referral_source, _ = CtwaReferralSource.get_or_create_for_org(
-            org, source_id, source_type
-        )
+        referral_source, _ = CtwaReferralSource.get_or_create_for_org(org, source_id, source_type)
 
     defaults = {"timestamp": timezone.now()}
     defaults.update(kwargs)
@@ -163,9 +155,7 @@ class ConversionEventAPITest(TembaTest):
         self.jwt_auth_patcher.start()
         self.addCleanup(self.jwt_auth_patcher.stop)
         # Patch WhatsAppCloudType.activate para evitar erro de configuração obrigatória
-        self.activate_patcher = patch.object(
-            WhatsAppCloudType, "activate", return_value=None
-        )
+        self.activate_patcher = patch.object(WhatsAppCloudType, "activate", return_value=None)
         self.activate_patcher.start()
         self.addCleanup(self.activate_patcher.stop)
         # Create test channel with Meta configuration
@@ -251,20 +241,14 @@ class ConversionEventAPITest(TembaTest):
                 self.assertEqual(event_data["project"], str(self.org.proj_uuid))
 
                 # Verify all payload data is in metadata
-                self.assertEqual(
-                    event_data["metadata"]["channel"], str(self.channel.uuid)
-                )
+                self.assertEqual(event_data["metadata"]["channel"], str(self.channel.uuid))
                 self.assertEqual(event_data["metadata"]["ctwa_id"], "test_clid_123")
                 self.assertEqual(event_data["metadata"]["waba_id"], "test_waba_123")
                 self.assertEqual(event_data["metadata"]["custom_field"], "custom_value")
                 self.assertEqual(event_data["metadata"]["order_form_id"], "12345")
                 self.assertEqual(event_data["metadata"]["value"], "100.00")
-                self.assertEqual(
-                    event_data["metadata"]["another_field"], "another_value"
-                )
-                self.assertNotIn(
-                    "ctwa_id", event_data
-                )  # Verify ctwa_id is not in main payload
+                self.assertEqual(event_data["metadata"]["another_field"], "another_value")
+                self.assertNotIn("ctwa_id", event_data)  # Verify ctwa_id is not in main payload
 
     def test_successful_conversion_without_ctwa(self):
         """Test successful conversion event without CTWA data - should only send to Datalake"""
@@ -291,9 +275,7 @@ class ConversionEventAPITest(TembaTest):
             self.assertEqual(response.status_code, 200)
             response_data = response.json()
             self.assertEqual(response_data["status"], "success")
-            self.assertEqual(
-                response_data["message"], "Event sent to Datalake successfully"
-            )
+            self.assertEqual(response_data["message"], "Event sent to Datalake successfully")
 
             # Verify Datalake call
             mock_send_event.assert_called_once()
@@ -307,9 +289,7 @@ class ConversionEventAPITest(TembaTest):
             self.assertEqual(event_data["metadata"]["custom_field"], "custom_value")
             self.assertEqual(event_data["metadata"]["order_form_id"], "12345")
             self.assertEqual(event_data["metadata"]["value"], "100.00")
-            self.assertNotIn(
-                "ctwa_id", event_data
-            )  # Verify ctwa_id is not in main payload
+            self.assertNotIn("ctwa_id", event_data)  # Verify ctwa_id is not in main payload
 
     def test_datalake_error_handling(self):
         """Test handling of Datalake API errors"""
@@ -395,9 +375,7 @@ class ConversionEventAPITest(TembaTest):
                 self.assertEqual(event_data["value"], "purchase")
                 self.assertEqual(event_data["value_type"], "string")
                 self.assertEqual(event_data["project"], str(self.org.proj_uuid))
-                self.assertEqual(
-                    event_data["contact_urn"], self.valid_payload["contact_urn"]
-                )
+                self.assertEqual(event_data["contact_urn"], self.valid_payload["contact_urn"])
                 self.assertEqual(event_data["metadata"]["value"], "123.45")
                 self.assertEqual(event_data["metadata"]["currency"], "USD")
                 self.assertEqual(event_data["metadata"]["custom_field"], "custom_value")
@@ -472,9 +450,7 @@ class ConversionEventAPITest(TembaTest):
             self.assertEqual(response.status_code, 200)
             response_data = response.json()
             self.assertEqual(response_data["status"], "success")
-            self.assertEqual(
-                response_data["message"], "Event sent to Datalake successfully"
-            )
+            self.assertEqual(response_data["message"], "Event sent to Datalake successfully")
 
             # Verify Datalake call
             mock_send_event.assert_called_once()
@@ -489,9 +465,7 @@ class ConversionEventAPITest(TembaTest):
             self.org.proj_uuid = uuid4()
             self.org.save(update_fields=["proj_uuid"])
 
-            channel_without_dataset = self.create_channel(
-                "WAC", "No Dataset Channel", "12065551213", config={}
-            )
+            channel_without_dataset = self.create_channel("WAC", "No Dataset Channel", "12065551213", config={})
             create_test_ctwa(
                 ctwa_clid="test_clid_456",
                 channel_uuid=channel_without_dataset.uuid,
@@ -511,17 +485,13 @@ class ConversionEventAPITest(TembaTest):
             self.assertEqual(response.status_code, 200)
             response_data = response.json()
             self.assertEqual(response_data["status"], "success")
-            self.assertEqual(
-                response_data["message"], "Event sent to Datalake successfully"
-            )
+            self.assertEqual(response_data["message"], "Event sent to Datalake successfully")
 
             # Verify Datalake call
             mock_send_event.assert_called_once()
             datalake_call = mock_send_event.call_args
             event_data = datalake_call[0][1]
-            self.assertEqual(
-                event_data["metadata"]["channel"], str(channel_without_dataset.uuid)
-            )
+            self.assertEqual(event_data["metadata"]["channel"], str(channel_without_dataset.uuid))
 
     def test_missing_access_token(self):
         with override_settings(WHATSAPP_ADMIN_SYSTEM_USER_TOKEN=""):
@@ -533,9 +503,7 @@ class ConversionEventAPITest(TembaTest):
             self.assertEqual(response.status_code, 500)
             response_data = response.json()
             self.assertEqual(response_data["error"], "Meta and Datalake Error")
-            self.assertIn(
-                "Meta: Meta access token not configured", response_data["detail"]
-            )
+            self.assertIn("Meta: Meta access token not configured", response_data["detail"])
 
     def test_meta_api_error_handling(self):
         with patch("temba.conversion_events.views.requests.post") as mock_post:
@@ -628,9 +596,7 @@ class ConversionEventAPITest(TembaTest):
             self.assertEqual(response.status_code, 200)
             response_data = response.json()
             self.assertEqual(response_data["status"], "success")
-            self.assertEqual(
-                response_data["message"], "Event sent to Datalake successfully"
-            )
+            self.assertEqual(response_data["message"], "Event sent to Datalake successfully")
 
             # Verify Datalake call
             mock_send_event.assert_called_once()
@@ -662,9 +628,7 @@ class ConversionEventAPITest(TembaTest):
 
     def test_unexpected_error(self):
         """Test handling of unexpected errors in the main try-except block"""
-        with patch(
-            "temba.conversion_events.views.ConversionEventSerializer"
-        ) as mock_serializer:
+        with patch("temba.conversion_events.views.ConversionEventSerializer") as mock_serializer:
             # Simulate an unexpected error that's not JSON related
             mock_serializer.side_effect = Exception("Unexpected internal error")
 
@@ -723,9 +687,7 @@ class ConversionEventAPITest(TembaTest):
                 self.assertEqual(response.status_code, 200)
                 response_data = response.json()
                 self.assertEqual(response_data["status"], "success")
-                self.assertEqual(
-                    response_data["message"], "Event sent to Datalake successfully"
-                )
+                self.assertEqual(response_data["message"], "Event sent to Datalake successfully")
 
                 # Verify Meta API was not called
                 mock_post.assert_not_called()
@@ -780,9 +742,7 @@ class ConversionEventAPITest(TembaTest):
                 success, error = view._send_to_meta({}, "test_dataset")
 
                 self.assertFalse(success)
-                self.assertEqual(
-                    error, "Network error sending to Meta: Network timeout"
-                )
+                self.assertEqual(error, "Network error sending to Meta: Network timeout")
 
     def test_channel_and_org_not_found_direct(self):
         """Test _send_to_datalake when channel and org are not found"""
@@ -792,25 +752,17 @@ class ConversionEventAPITest(TembaTest):
         view = ConversionEventView()
 
         # Test with non-existent channel
-        success, error = view._send_to_datalake(
-            "lead", "non-existent-uuid", "whatsapp:1234567890", None, {}
-        )
+        success, error = view._send_to_datalake("lead", "non-existent-uuid", "whatsapp:1234567890", None, {})
         self.assertFalse(success)
         self.assertEqual(error, "Channel not found")
 
         # Test with non-existent org
-        with patch(
-            "temba.channels.models.Channel.objects.filter"
-        ) as mock_channel_filter:
+        with patch("temba.channels.models.Channel.objects.filter") as mock_channel_filter:
             mock_channel = Mock()
             mock_channel.org_id = 999999  # Non-existent org ID
-            mock_channel_filter.return_value.only.return_value.first.return_value = (
-                mock_channel
-            )
+            mock_channel_filter.return_value.only.return_value.first.return_value = mock_channel
 
-            success, error = view._send_to_datalake(
-                "lead", "some-uuid", "whatsapp:1234567890", None, {}
-            )
+            success, error = view._send_to_datalake("lead", "some-uuid", "whatsapp:1234567890", None, {})
             self.assertFalse(success)
             self.assertEqual(error, "Organization not found")
 
@@ -820,24 +772,18 @@ class ConversionEventAPITest(TembaTest):
 
         view = ConversionEventView()
 
-        with patch(
-            "temba.channels.models.Channel.objects.filter"
-        ) as mock_channel_filter, patch(
+        with patch("temba.channels.models.Channel.objects.filter") as mock_channel_filter, patch(
             "temba.orgs.models.Org.objects.filter"
         ) as mock_org_filter:
             # Setup channel mock to return a valid channel
             mock_channel = Mock()
             mock_channel.org_id = 123
-            mock_channel_filter.return_value.only.return_value.first.return_value = (
-                mock_channel
-            )
+            mock_channel_filter.return_value.only.return_value.first.return_value = mock_channel
 
             # Setup org filter to raise an exception
             mock_org_filter.side_effect = Exception("Database error during org lookup")
 
-            success, error = view._send_to_datalake(
-                "lead", "some-uuid", "whatsapp:1234567890", None, {}
-            )
+            success, error = view._send_to_datalake("lead", "some-uuid", "whatsapp:1234567890", None, {})
             self.assertFalse(success)
             self.assertEqual(error, "Organization not found")
 
@@ -876,9 +822,7 @@ class ConversionEventAPITest(TembaTest):
                 self.assertEqual(response.status_code, 200)
                 response_data = response.json()
                 self.assertEqual(response_data["status"], "success")
-                self.assertEqual(
-                    response_data["message"], "Event sent to Datalake successfully"
-                )
+                self.assertEqual(response_data["message"], "Event sent to Datalake successfully")
 
                 # Verify Meta API was called and failed
                 mock_post.assert_called_once()
@@ -923,9 +867,7 @@ class CTWAModelTest(TembaTest):
             contact_urn="whatsapp:9999999999",
         )
         self.assertIsNone(ctwa.ctwa_clid)
-        self.assertEqual(
-            str(ctwa), f"CTWA Data - CLID: no-clid, Channel: {self.channel.uuid}"
-        )
+        self.assertEqual(str(ctwa), f"CTWA Data - CLID: no-clid, Channel: {self.channel.uuid}")
 
     def test_ctwa_str_method(self):
         """Test CTWA string representation"""
@@ -964,9 +906,7 @@ class CTWAModelTest(TembaTest):
         self.assertEqual(specific_ctwa, ctwa1)
 
         # Test combined filter (as used in the view)
-        lookup_ctwa = CTWA.objects.filter(
-            channel_uuid=self.channel.uuid, contact_urn="whatsapp:2222222222"
-        ).first()
+        lookup_ctwa = CTWA.objects.filter(channel_uuid=self.channel.uuid, contact_urn="whatsapp:2222222222").first()
         self.assertEqual(lookup_ctwa, ctwa2)
 
     def test_whatsapp_urn_format_handling(self):
@@ -1028,7 +968,9 @@ class JWTModuleAuthenticationTestCase(TestCase):
     def setUp(self):
         self.factory = APIRequestFactory()
         self.auth = JWTModuleAuthentication()
-        self.mock_public_key = "-----BEGIN PUBLIC KEY-----\nMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEA...\n-----END PUBLIC KEY-----"
+        self.mock_public_key = (
+            "-----BEGIN PUBLIC KEY-----\nMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEA...\n-----END PUBLIC KEY-----"
+        )
         self.sample_payload = {
             "project_uuid": "test-project-123",
             "exp": 9999999999,
@@ -1050,9 +992,7 @@ class JWTModuleAuthenticationTestCase(TestCase):
             request.headers = {}
             with self.assertRaises(AuthenticationFailed) as context:
                 self.auth.authenticate(request)
-            self.assertIn(
-                "Missing or invalid Authorization header", str(context.exception)
-            )
+            self.assertIn("Missing or invalid Authorization header", str(context.exception))
 
     def test_authenticate_invalid_authorization_header(self):
         with patch("temba.conversion_events.jwt_auth.settings") as mock_settings:
@@ -1061,9 +1001,7 @@ class JWTModuleAuthenticationTestCase(TestCase):
             request.headers = {"Authorization": "InvalidFormat"}
             with self.assertRaises(AuthenticationFailed) as context:
                 self.auth.authenticate(request)
-            self.assertIn(
-                "Missing or invalid Authorization header", str(context.exception)
-            )
+            self.assertIn("Missing or invalid Authorization header", str(context.exception))
 
     @patch("temba.conversion_events.jwt_auth.jwt.decode")
     @patch("temba.conversion_events.jwt_auth.settings")
@@ -1116,9 +1054,7 @@ class JWTModuleAuthenticationTestCase(TestCase):
         self.assertIn("Invalid token", str(context.exception))
 
     def test_authenticate_verify_jwt_decode_called_correctly(self):
-        with patch(
-            "temba.conversion_events.jwt_auth.jwt.decode"
-        ) as mock_jwt_decode, patch(
+        with patch("temba.conversion_events.jwt_auth.jwt.decode") as mock_jwt_decode, patch(
             "temba.conversion_events.jwt_auth.settings"
         ) as mock_settings:
             mock_settings.JWT_PUBLIC_KEY = self.mock_public_key
@@ -1177,9 +1113,7 @@ class CtwaReferralSourceModelTest(TembaTest):
 
     def test_get_or_create_for_org_requires_org(self):
         with self.assertRaises(ValueError):
-            CtwaReferralSource.get_or_create_for_org(
-                None, "ad-1", CtwaReferralSource.SOURCE_TYPE_AD
-            )
+            CtwaReferralSource.get_or_create_for_org(None, "ad-1", CtwaReferralSource.SOURCE_TYPE_AD)
 
     def test_same_source_allowed_for_different_orgs(self):
         source_id = "shared-ad"
@@ -1199,9 +1133,7 @@ class CtwaReferralSourceModelTest(TembaTest):
 
     def test_same_org_source_id_and_type_is_rejected(self):
         source_id = "dup-ad"
-        CtwaReferralSource.get_or_create_for_org(
-            self.org, source_id, CtwaReferralSource.SOURCE_TYPE_AD
-        )
+        CtwaReferralSource.get_or_create_for_org(self.org, source_id, CtwaReferralSource.SOURCE_TYPE_AD)
 
         with transaction.atomic():
             with self.assertRaises(IntegrityError):
@@ -1228,9 +1160,7 @@ class CtwaReferralSourceBackfillTest(TembaTest):
     def setUp(self):
         super().setUp()
         self.channel = self.create_channel("WAC", "Org1 Channel", "1111111111")
-        self.channel2 = self.create_channel(
-            "WAC", "Org2 Channel", "2222222222", org=self.org2
-        )
+        self.channel2 = self.create_channel("WAC", "Org2 Channel", "2222222222", org=self.org2)
 
     def test_org_ids_resolved_from_ctwa_channel(self):
         source, _ = CtwaReferralSource.get_or_create_for_org(
@@ -1247,9 +1177,7 @@ class CtwaReferralSourceBackfillTest(TembaTest):
         org_map = org_ids_by_source_id([source.id], CTWA, Channel)
         self.assertEqual(org_map[source.id], [self.org.id])
 
-        apply_orgs_to_source(
-            source, org_map[source.id], CtwaReferralSource, CTWA, Channel
-        )
+        apply_orgs_to_source(source, org_map[source.id], CtwaReferralSource, CTWA, Channel)
         source.refresh_from_db()
         self.assertEqual(source.org_id, self.org.id)
 
@@ -1275,9 +1203,7 @@ class CtwaReferralSourceBackfillTest(TembaTest):
         org_map = org_ids_by_source_id([source.id], CTWA, Channel)
         self.assertEqual(set(org_map[source.id]), {self.org.id, self.org2.id})
 
-        apply_orgs_to_source(
-            source, org_map[source.id], CtwaReferralSource, CTWA, Channel
-        )
+        apply_orgs_to_source(source, org_map[source.id], CtwaReferralSource, CTWA, Channel)
 
         source.refresh_from_db()
         ctwa_org1.refresh_from_db()
@@ -1300,9 +1226,7 @@ class CtwaReferralSourceBackfillTest(TembaTest):
         self.assertNotEqual(ctwa_org1.referral_source_id, ctwa_org2.referral_source_id)
 
     def test_backfill_processes_sources_and_clones_shared_orgs(self):
-        source, _ = CtwaReferralSource.get_or_create_for_org(
-            self.org, "batched-ad", CtwaReferralSource.SOURCE_TYPE_AD
-        )
+        source, _ = CtwaReferralSource.get_or_create_for_org(self.org, "batched-ad", CtwaReferralSource.SOURCE_TYPE_AD)
         create_test_ctwa(
             ctwa_clid="clid-batch-1",
             channel_uuid=self.channel.uuid,
@@ -1318,49 +1242,35 @@ class CtwaReferralSourceBackfillTest(TembaTest):
             referral_source=source,
         )
 
-        backfill_ctwa_referral_source_org(
-            CtwaReferralSource, CTWA, Channel, source_ids=[source.id]
-        )
+        backfill_ctwa_referral_source_org(CtwaReferralSource, CTWA, Channel, source_ids=[source.id])
 
         self.assertEqual(
             CtwaReferralSource.objects.filter(source_id="batched-ad").count(),
             2,
         )
         self.assertEqual(
-            set(
-                CtwaReferralSource.objects.filter(source_id="batched-ad").values_list(
-                    "org_id", flat=True
-                )
-            ),
+            set(CtwaReferralSource.objects.filter(source_id="batched-ad").values_list("org_id", flat=True)),
             {self.org.id, self.org2.id},
         )
 
     def test_backfill_logs_when_org_cannot_be_resolved(self):
-        source, _ = CtwaReferralSource.get_or_create_for_org(
-            self.org, "orphan-ad", CtwaReferralSource.SOURCE_TYPE_AD
-        )
+        source, _ = CtwaReferralSource.get_or_create_for_org(self.org, "orphan-ad", CtwaReferralSource.SOURCE_TYPE_AD)
 
         with self.assertLogs(
             "temba.conversion_events.migrations.0004_backfill_ctwareferralsource_org",
             level="WARNING",
         ) as logs:
-            backfill_ctwa_referral_source_org(
-                CtwaReferralSource, CTWA, Channel, source_ids=[source.id]
-            )
+            backfill_ctwa_referral_source_org(CtwaReferralSource, CTWA, Channel, source_ids=[source.id])
 
         self.assertTrue(any(f"id={source.id}" in message for message in logs.output))
         source.refresh_from_db()
         self.assertEqual(source.org_id, self.org.id)
 
     def test_backfill_is_noop_when_all_sources_have_org(self):
-        CtwaReferralSource.get_or_create_for_org(
-            self.org, "has-org", CtwaReferralSource.SOURCE_TYPE_AD
-        )
+        CtwaReferralSource.get_or_create_for_org(self.org, "has-org", CtwaReferralSource.SOURCE_TYPE_AD)
         backfill_ctwa_referral_source_org(CtwaReferralSource, CTWA, Channel)
         self.assertEqual(
-            CtwaReferralSource.objects.filter(
-                source_id="has-org", org=self.org
-            ).count(),
+            CtwaReferralSource.objects.filter(source_id="has-org", org=self.org).count(),
             1,
         )
 

--- a/temba/conversion_events/tests.py
+++ b/temba/conversion_events/tests.py
@@ -1,5 +1,6 @@
 import json
 from importlib import import_module
+from types import SimpleNamespace
 from unittest.mock import Mock, patch
 from uuid import uuid4
 
@@ -9,8 +10,9 @@ from rest_framework.exceptions import AuthenticationFailed
 from rest_framework.test import APIRequestFactory
 
 from django.contrib.auth.models import AnonymousUser
-from django.db import IntegrityError, transaction
+from django.db import IntegrityError, connection, transaction
 from django.test import TestCase, override_settings
+from django.test.utils import CaptureQueriesContext
 from django.utils import timezone
 
 from temba.channels.models import Channel
@@ -23,7 +25,7 @@ from temba.tests import TembaTest
 _backfill = import_module("temba.conversion_events.migrations.0004_backfill_ctwareferralsource_org")
 apply_orgs_to_source = _backfill.apply_orgs_to_source
 backfill_ctwa_referral_source_org = _backfill.backfill_ctwa_referral_source_org
-org_ids_by_source_id = _backfill.org_ids_by_source_id
+org_channels_by_source_id = _backfill.org_channels_by_source_id
 
 
 def create_test_ctwa(**kwargs):
@@ -1162,7 +1164,18 @@ class CtwaReferralSourceBackfillTest(TembaTest):
         self.channel = self.create_channel("WAC", "Org1 Channel", "1111111111")
         self.channel2 = self.create_channel("WAC", "Org2 Channel", "2222222222", org=self.org2)
 
-    def test_org_ids_resolved_from_ctwa_channel(self):
+    def _null_org_standin(self, source):
+        return SimpleNamespace(
+            id=source.id,
+            org_id=None,
+            source_id=source.source_id,
+            source_type=source.source_type,
+            source_url=source.source_url,
+            headline=source.headline,
+            body=source.body,
+        )
+
+    def test_null_org_source_is_assigned_from_ctwa_channel(self):
         source, _ = CtwaReferralSource.get_or_create_for_org(
             self.org2, "ad-from-channel", CtwaReferralSource.SOURCE_TYPE_AD
         )
@@ -1174,10 +1187,10 @@ class CtwaReferralSourceBackfillTest(TembaTest):
             referral_source=source,
         )
 
-        org_map = org_ids_by_source_id([source.id], CTWA, Channel)
-        self.assertEqual(org_map[source.id], [self.org.id])
+        org_map = org_channels_by_source_id([source.id], CTWA, Channel)
+        self.assertEqual(list(org_map[source.id]), [self.org.id])
 
-        apply_orgs_to_source(source, org_map[source.id], CtwaReferralSource, CTWA, Channel)
+        apply_orgs_to_source(self._null_org_standin(source), org_map[source.id], CtwaReferralSource, CTWA)
         source.refresh_from_db()
         self.assertEqual(source.org_id, self.org.id)
 
@@ -1200,10 +1213,10 @@ class CtwaReferralSourceBackfillTest(TembaTest):
             referral_source=source,
         )
 
-        org_map = org_ids_by_source_id([source.id], CTWA, Channel)
+        org_map = org_channels_by_source_id([source.id], CTWA, Channel)
         self.assertEqual(set(org_map[source.id]), {self.org.id, self.org2.id})
 
-        apply_orgs_to_source(source, org_map[source.id], CtwaReferralSource, CTWA, Channel)
+        apply_orgs_to_source(source, org_map[source.id], CtwaReferralSource, CTWA)
 
         source.refresh_from_db()
         ctwa_org1.refresh_from_db()
@@ -1212,18 +1225,59 @@ class CtwaReferralSourceBackfillTest(TembaTest):
         clone = CtwaReferralSource.objects.exclude(id=source.id).get(
             source_id="shared-ad", source_type=CtwaReferralSource.SOURCE_TYPE_AD
         )
-        self.assertEqual(source.org_id, org_map[source.id][0])
-        self.assertEqual(clone.org_id, org_map[source.id][1])
+        self.assertEqual(source.org_id, self.org.id)
+        self.assertEqual(clone.org_id, self.org2.id)
         self.assertEqual(clone.headline, "Hello")
-        self.assertEqual(
-            ctwa_org1.referral_source_id,
-            source.id if source.org_id == self.org.id else clone.id,
+        self.assertEqual(ctwa_org1.referral_source_id, source.id)
+        self.assertEqual(ctwa_org2.referral_source_id, clone.id)
+
+    def test_existing_org_is_preserved_when_ctwas_resolve_to_a_different_org(self):
+        source, _ = CtwaReferralSource.get_or_create_for_org(
+            self.org, "mismatch-ad", CtwaReferralSource.SOURCE_TYPE_AD
         )
-        self.assertEqual(
-            ctwa_org2.referral_source_id,
-            clone.id if source.org_id == self.org.id else source.id,
+        ctwa = create_test_ctwa(
+            ctwa_clid="clid-mismatch",
+            channel_uuid=self.channel2.uuid,
+            waba="waba2",
+            contact_urn="whatsapp:2222222222",
+            referral_source=source,
         )
-        self.assertNotEqual(ctwa_org1.referral_source_id, ctwa_org2.referral_source_id)
+
+        with patch.object(_backfill.logger, "warning") as mock_warning:
+            backfill_ctwa_referral_source_org(CtwaReferralSource, CTWA, Channel, source_ids=[source.id])
+
+        mock_warning.assert_called_once()
+        warning = mock_warning.call_args[0][0]
+        self.assertIn(f"id={source.id}", warning)
+        self.assertIn(f"org_id={self.org.id}", warning)
+
+        source.refresh_from_db()
+        ctwa.refresh_from_db()
+        clone = CtwaReferralSource.objects.exclude(id=source.id).get(
+            source_id="mismatch-ad", source_type=CtwaReferralSource.SOURCE_TYPE_AD
+        )
+        self.assertEqual(source.org_id, self.org.id)
+        self.assertEqual(clone.org_id, self.org2.id)
+        self.assertEqual(ctwa.referral_source_id, clone.id)
+
+    def test_apply_orgs_to_source_does_not_query_channels(self):
+        source, _ = CtwaReferralSource.get_or_create_for_org(
+            self.org, "no-channel-query-ad", CtwaReferralSource.SOURCE_TYPE_AD
+        )
+        create_test_ctwa(
+            ctwa_clid="clid-no-channel-query",
+            channel_uuid=self.channel2.uuid,
+            waba="waba2",
+            contact_urn="whatsapp:2222222222",
+            referral_source=source,
+        )
+        org_map = org_channels_by_source_id([source.id], CTWA, Channel)
+
+        with CaptureQueriesContext(connection) as captured:
+            apply_orgs_to_source(source, org_map[source.id], CtwaReferralSource, CTWA)
+
+        channel_queries = [query["sql"] for query in captured.captured_queries if "channels_channel" in query["sql"]]
+        self.assertEqual(channel_queries, [])
 
     def test_backfill_processes_sources_and_clones_shared_orgs(self):
         source, _ = CtwaReferralSource.get_or_create_for_org(self.org, "batched-ad", CtwaReferralSource.SOURCE_TYPE_AD)
@@ -1274,13 +1328,27 @@ class CtwaReferralSourceBackfillTest(TembaTest):
             1,
         )
 
-    def test_org_ids_by_source_id_returns_empty_for_no_ids(self):
-        self.assertEqual(org_ids_by_source_id([], CTWA, Channel), {})
+    def test_org_channels_by_source_id_returns_empty_for_no_ids(self):
+        self.assertEqual(org_channels_by_source_id([], CTWA, Channel), {})
 
     def test_apply_orgs_to_source_skips_empty_org_ids(self):
         source, _ = CtwaReferralSource.get_or_create_for_org(
             self.org, "unchanged-ad", CtwaReferralSource.SOURCE_TYPE_AD
         )
-        apply_orgs_to_source(source, [], CtwaReferralSource, CTWA, Channel)
+        apply_orgs_to_source(source, {}, CtwaReferralSource, CTWA)
         source.refresh_from_db()
         self.assertEqual(source.org_id, self.org.id)
+
+    def test_forwards_loads_models_and_runs_backfill(self):
+        apps = Mock()
+        models = {
+            ("conversion_events", "CtwaReferralSource"): CtwaReferralSource,
+            ("conversion_events", "CTWA"): CTWA,
+            ("channels", "Channel"): Channel,
+        }
+        apps.get_model.side_effect = lambda app, model: models[(app, model)]
+
+        with patch.object(_backfill, "backfill_ctwa_referral_source_org") as mock_backfill:
+            _backfill.forwards(apps, schema_editor=None)
+
+        mock_backfill.assert_called_once_with(CtwaReferralSource, CTWA, Channel)

--- a/temba/conversion_events/tests.py
+++ b/temba/conversion_events/tests.py
@@ -1,4 +1,5 @@
 import json
+from importlib import import_module
 from unittest.mock import Mock, patch
 from uuid import uuid4
 
@@ -8,24 +9,43 @@ from rest_framework.exceptions import AuthenticationFailed
 from rest_framework.test import APIRequestFactory
 
 from django.contrib.auth.models import AnonymousUser
+from django.db import IntegrityError, transaction
 from django.test import TestCase, override_settings
 from django.utils import timezone
 
+from temba.channels.models import Channel
 from temba.channels.types.whatsapp_cloud.type import WhatsAppCloudType
 from temba.conversion_events.jwt_auth import JWTModuleAuthentication, JWTModuleAuthMixin
 from temba.conversion_events.models import CTWA, CtwaReferralSource
 from temba.conversion_events.serializers import ConversionEventSerializer
 from temba.tests import TembaTest
 
+_backfill = import_module(
+    "temba.conversion_events.migrations.0004_backfill_ctwareferralsource_org"
+)
+apply_orgs_to_source = _backfill.apply_orgs_to_source
+backfill_ctwa_referral_source_org = _backfill.backfill_ctwa_referral_source_org
+org_ids_by_source_id = _backfill.org_ids_by_source_id
+
 
 def create_test_ctwa(**kwargs):
     referral_source = kwargs.pop("referral_source", None)
+    org = kwargs.pop("org", None)
     if referral_source is None:
         source_id = kwargs.pop("source_id", f"test-source-{uuid4()}")
         source_type = kwargs.pop("source_type", CtwaReferralSource.SOURCE_TYPE_AD)
-        referral_source, _ = CtwaReferralSource.objects.get_or_create(
-            source_id=source_id,
-            source_type=source_type,
+        if org is None:
+            channel_uuid = kwargs.get("channel_uuid")
+            if channel_uuid is not None:
+                channel = (
+                    Channel.objects.filter(uuid=str(channel_uuid))
+                    .select_related("org")
+                    .first()
+                )
+                if channel is not None:
+                    org = channel.org
+        referral_source, _ = CtwaReferralSource.get_or_create_for_org(
+            org, source_id, source_type
         )
 
     defaults = {"timestamp": timezone.now()}
@@ -143,7 +163,9 @@ class ConversionEventAPITest(TembaTest):
         self.jwt_auth_patcher.start()
         self.addCleanup(self.jwt_auth_patcher.stop)
         # Patch WhatsAppCloudType.activate para evitar erro de configuração obrigatória
-        self.activate_patcher = patch.object(WhatsAppCloudType, "activate", return_value=None)
+        self.activate_patcher = patch.object(
+            WhatsAppCloudType, "activate", return_value=None
+        )
         self.activate_patcher.start()
         self.addCleanup(self.activate_patcher.stop)
         # Create test channel with Meta configuration
@@ -152,7 +174,10 @@ class ConversionEventAPITest(TembaTest):
             "Test WhatsApp Channel",
             "12065551212",
             country="US",
-            config={"meta_dataset_id": "test_dataset_123", "wa_waba_id": "test_waba_123"},
+            config={
+                "meta_dataset_id": "test_dataset_123",
+                "wa_waba_id": "test_waba_123",
+            },
         )
         # Create CTWA data for testing
         self.ctwa_data = create_test_ctwa(
@@ -226,14 +251,20 @@ class ConversionEventAPITest(TembaTest):
                 self.assertEqual(event_data["project"], str(self.org.proj_uuid))
 
                 # Verify all payload data is in metadata
-                self.assertEqual(event_data["metadata"]["channel"], str(self.channel.uuid))
+                self.assertEqual(
+                    event_data["metadata"]["channel"], str(self.channel.uuid)
+                )
                 self.assertEqual(event_data["metadata"]["ctwa_id"], "test_clid_123")
                 self.assertEqual(event_data["metadata"]["waba_id"], "test_waba_123")
                 self.assertEqual(event_data["metadata"]["custom_field"], "custom_value")
                 self.assertEqual(event_data["metadata"]["order_form_id"], "12345")
                 self.assertEqual(event_data["metadata"]["value"], "100.00")
-                self.assertEqual(event_data["metadata"]["another_field"], "another_value")
-                self.assertNotIn("ctwa_id", event_data)  # Verify ctwa_id is not in main payload
+                self.assertEqual(
+                    event_data["metadata"]["another_field"], "another_value"
+                )
+                self.assertNotIn(
+                    "ctwa_id", event_data
+                )  # Verify ctwa_id is not in main payload
 
     def test_successful_conversion_without_ctwa(self):
         """Test successful conversion event without CTWA data - should only send to Datalake"""
@@ -260,7 +291,9 @@ class ConversionEventAPITest(TembaTest):
             self.assertEqual(response.status_code, 200)
             response_data = response.json()
             self.assertEqual(response_data["status"], "success")
-            self.assertEqual(response_data["message"], "Event sent to Datalake successfully")
+            self.assertEqual(
+                response_data["message"], "Event sent to Datalake successfully"
+            )
 
             # Verify Datalake call
             mock_send_event.assert_called_once()
@@ -274,7 +307,9 @@ class ConversionEventAPITest(TembaTest):
             self.assertEqual(event_data["metadata"]["custom_field"], "custom_value")
             self.assertEqual(event_data["metadata"]["order_form_id"], "12345")
             self.assertEqual(event_data["metadata"]["value"], "100.00")
-            self.assertNotIn("ctwa_id", event_data)  # Verify ctwa_id is not in main payload
+            self.assertNotIn(
+                "ctwa_id", event_data
+            )  # Verify ctwa_id is not in main payload
 
     def test_datalake_error_handling(self):
         """Test handling of Datalake API errors"""
@@ -360,7 +395,9 @@ class ConversionEventAPITest(TembaTest):
                 self.assertEqual(event_data["value"], "purchase")
                 self.assertEqual(event_data["value_type"], "string")
                 self.assertEqual(event_data["project"], str(self.org.proj_uuid))
-                self.assertEqual(event_data["contact_urn"], self.valid_payload["contact_urn"])
+                self.assertEqual(
+                    event_data["contact_urn"], self.valid_payload["contact_urn"]
+                )
                 self.assertEqual(event_data["metadata"]["value"], "123.45")
                 self.assertEqual(event_data["metadata"]["currency"], "USD")
                 self.assertEqual(event_data["metadata"]["custom_field"], "custom_value")
@@ -435,7 +472,9 @@ class ConversionEventAPITest(TembaTest):
             self.assertEqual(response.status_code, 200)
             response_data = response.json()
             self.assertEqual(response_data["status"], "success")
-            self.assertEqual(response_data["message"], "Event sent to Datalake successfully")
+            self.assertEqual(
+                response_data["message"], "Event sent to Datalake successfully"
+            )
 
             # Verify Datalake call
             mock_send_event.assert_called_once()
@@ -450,7 +489,9 @@ class ConversionEventAPITest(TembaTest):
             self.org.proj_uuid = uuid4()
             self.org.save(update_fields=["proj_uuid"])
 
-            channel_without_dataset = self.create_channel("WAC", "No Dataset Channel", "12065551213", config={})
+            channel_without_dataset = self.create_channel(
+                "WAC", "No Dataset Channel", "12065551213", config={}
+            )
             create_test_ctwa(
                 ctwa_clid="test_clid_456",
                 channel_uuid=channel_without_dataset.uuid,
@@ -470,13 +511,17 @@ class ConversionEventAPITest(TembaTest):
             self.assertEqual(response.status_code, 200)
             response_data = response.json()
             self.assertEqual(response_data["status"], "success")
-            self.assertEqual(response_data["message"], "Event sent to Datalake successfully")
+            self.assertEqual(
+                response_data["message"], "Event sent to Datalake successfully"
+            )
 
             # Verify Datalake call
             mock_send_event.assert_called_once()
             datalake_call = mock_send_event.call_args
             event_data = datalake_call[0][1]
-            self.assertEqual(event_data["metadata"]["channel"], str(channel_without_dataset.uuid))
+            self.assertEqual(
+                event_data["metadata"]["channel"], str(channel_without_dataset.uuid)
+            )
 
     def test_missing_access_token(self):
         with override_settings(WHATSAPP_ADMIN_SYSTEM_USER_TOKEN=""):
@@ -488,7 +533,9 @@ class ConversionEventAPITest(TembaTest):
             self.assertEqual(response.status_code, 500)
             response_data = response.json()
             self.assertEqual(response_data["error"], "Meta and Datalake Error")
-            self.assertIn("Meta: Meta access token not configured", response_data["detail"])
+            self.assertIn(
+                "Meta: Meta access token not configured", response_data["detail"]
+            )
 
     def test_meta_api_error_handling(self):
         with patch("temba.conversion_events.views.requests.post") as mock_post:
@@ -520,7 +567,10 @@ class ConversionEventAPITest(TembaTest):
                 self.assertEqual(response.status_code, 500)
                 response_data = response.json()
                 self.assertEqual(response_data["error"], "Meta and Datalake Error")
-                self.assertIn("Meta: Error sending to Meta: Network error", response_data["detail"])
+                self.assertIn(
+                    "Meta: Error sending to Meta: Network error",
+                    response_data["detail"],
+                )
 
     def test_invalid_json_handling(self):
         response = self.client.post(
@@ -578,7 +628,9 @@ class ConversionEventAPITest(TembaTest):
             self.assertEqual(response.status_code, 200)
             response_data = response.json()
             self.assertEqual(response_data["status"], "success")
-            self.assertEqual(response_data["message"], "Event sent to Datalake successfully")
+            self.assertEqual(
+                response_data["message"], "Event sent to Datalake successfully"
+            )
 
             # Verify Datalake call
             mock_send_event.assert_called_once()
@@ -610,7 +662,9 @@ class ConversionEventAPITest(TembaTest):
 
     def test_unexpected_error(self):
         """Test handling of unexpected errors in the main try-except block"""
-        with patch("temba.conversion_events.views.ConversionEventSerializer") as mock_serializer:
+        with patch(
+            "temba.conversion_events.views.ConversionEventSerializer"
+        ) as mock_serializer:
             # Simulate an unexpected error that's not JSON related
             mock_serializer.side_effect = Exception("Unexpected internal error")
 
@@ -669,7 +723,9 @@ class ConversionEventAPITest(TembaTest):
                 self.assertEqual(response.status_code, 200)
                 response_data = response.json()
                 self.assertEqual(response_data["status"], "success")
-                self.assertEqual(response_data["message"], "Event sent to Datalake successfully")
+                self.assertEqual(
+                    response_data["message"], "Event sent to Datalake successfully"
+                )
 
                 # Verify Meta API was not called
                 mock_post.assert_not_called()
@@ -724,7 +780,9 @@ class ConversionEventAPITest(TembaTest):
                 success, error = view._send_to_meta({}, "test_dataset")
 
                 self.assertFalse(success)
-                self.assertEqual(error, "Network error sending to Meta: Network timeout")
+                self.assertEqual(
+                    error, "Network error sending to Meta: Network timeout"
+                )
 
     def test_channel_and_org_not_found_direct(self):
         """Test _send_to_datalake when channel and org are not found"""
@@ -734,17 +792,25 @@ class ConversionEventAPITest(TembaTest):
         view = ConversionEventView()
 
         # Test with non-existent channel
-        success, error = view._send_to_datalake("lead", "non-existent-uuid", "whatsapp:1234567890", None, {})
+        success, error = view._send_to_datalake(
+            "lead", "non-existent-uuid", "whatsapp:1234567890", None, {}
+        )
         self.assertFalse(success)
         self.assertEqual(error, "Channel not found")
 
         # Test with non-existent org
-        with patch("temba.channels.models.Channel.objects.filter") as mock_channel_filter:
+        with patch(
+            "temba.channels.models.Channel.objects.filter"
+        ) as mock_channel_filter:
             mock_channel = Mock()
             mock_channel.org_id = 999999  # Non-existent org ID
-            mock_channel_filter.return_value.only.return_value.first.return_value = mock_channel
+            mock_channel_filter.return_value.only.return_value.first.return_value = (
+                mock_channel
+            )
 
-            success, error = view._send_to_datalake("lead", "some-uuid", "whatsapp:1234567890", None, {})
+            success, error = view._send_to_datalake(
+                "lead", "some-uuid", "whatsapp:1234567890", None, {}
+            )
             self.assertFalse(success)
             self.assertEqual(error, "Organization not found")
 
@@ -754,18 +820,24 @@ class ConversionEventAPITest(TembaTest):
 
         view = ConversionEventView()
 
-        with patch("temba.channels.models.Channel.objects.filter") as mock_channel_filter, patch(
+        with patch(
+            "temba.channels.models.Channel.objects.filter"
+        ) as mock_channel_filter, patch(
             "temba.orgs.models.Org.objects.filter"
         ) as mock_org_filter:
             # Setup channel mock to return a valid channel
             mock_channel = Mock()
             mock_channel.org_id = 123
-            mock_channel_filter.return_value.only.return_value.first.return_value = mock_channel
+            mock_channel_filter.return_value.only.return_value.first.return_value = (
+                mock_channel
+            )
 
             # Setup org filter to raise an exception
             mock_org_filter.side_effect = Exception("Database error during org lookup")
 
-            success, error = view._send_to_datalake("lead", "some-uuid", "whatsapp:1234567890", None, {})
+            success, error = view._send_to_datalake(
+                "lead", "some-uuid", "whatsapp:1234567890", None, {}
+            )
             self.assertFalse(success)
             self.assertEqual(error, "Organization not found")
 
@@ -804,7 +876,9 @@ class ConversionEventAPITest(TembaTest):
                 self.assertEqual(response.status_code, 200)
                 response_data = response.json()
                 self.assertEqual(response_data["status"], "success")
-                self.assertEqual(response_data["message"], "Event sent to Datalake successfully")
+                self.assertEqual(
+                    response_data["message"], "Event sent to Datalake successfully"
+                )
 
                 # Verify Meta API was called and failed
                 mock_post.assert_called_once()
@@ -839,6 +913,7 @@ class CTWAModelTest(TembaTest):
         self.assertEqual(ctwa.contact_urn, "whatsapp:1234567890")
         self.assertIsNotNone(ctwa.timestamp)
         self.assertIsNotNone(ctwa.referral_source)
+        self.assertEqual(ctwa.referral_source.org, self.org)
 
     def test_ctwa_without_clid(self):
         ctwa = create_test_ctwa(
@@ -848,7 +923,9 @@ class CTWAModelTest(TembaTest):
             contact_urn="whatsapp:9999999999",
         )
         self.assertIsNone(ctwa.ctwa_clid)
-        self.assertEqual(str(ctwa), f"CTWA Data - CLID: no-clid, Channel: {self.channel.uuid}")
+        self.assertEqual(
+            str(ctwa), f"CTWA Data - CLID: no-clid, Channel: {self.channel.uuid}"
+        )
 
     def test_ctwa_str_method(self):
         """Test CTWA string representation"""
@@ -887,7 +964,9 @@ class CTWAModelTest(TembaTest):
         self.assertEqual(specific_ctwa, ctwa1)
 
         # Test combined filter (as used in the view)
-        lookup_ctwa = CTWA.objects.filter(channel_uuid=self.channel.uuid, contact_urn="whatsapp:2222222222").first()
+        lookup_ctwa = CTWA.objects.filter(
+            channel_uuid=self.channel.uuid, contact_urn="whatsapp:2222222222"
+        ).first()
         self.assertEqual(lookup_ctwa, ctwa2)
 
     def test_whatsapp_urn_format_handling(self):
@@ -927,7 +1006,10 @@ class CTWAModelTest(TembaTest):
 
         # Test with non-WhatsApp URN (should use exact match)
         ctwa_other = create_test_ctwa(
-            ctwa_clid="clid_other", channel_uuid=self.channel.uuid, waba="waba_test3", contact_urn="tel:1234567890"
+            ctwa_clid="clid_other",
+            channel_uuid=self.channel.uuid,
+            waba="waba_test3",
+            contact_urn="tel:1234567890",
         )
 
         result = view._get_ctwa_data(self.channel.uuid, "tel:1234567890")
@@ -946,9 +1028,7 @@ class JWTModuleAuthenticationTestCase(TestCase):
     def setUp(self):
         self.factory = APIRequestFactory()
         self.auth = JWTModuleAuthentication()
-        self.mock_public_key = (
-            "-----BEGIN PUBLIC KEY-----\nMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEA...\n-----END PUBLIC KEY-----"
-        )
+        self.mock_public_key = "-----BEGIN PUBLIC KEY-----\nMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEA...\n-----END PUBLIC KEY-----"
         self.sample_payload = {
             "project_uuid": "test-project-123",
             "exp": 9999999999,
@@ -970,7 +1050,9 @@ class JWTModuleAuthenticationTestCase(TestCase):
             request.headers = {}
             with self.assertRaises(AuthenticationFailed) as context:
                 self.auth.authenticate(request)
-            self.assertIn("Missing or invalid Authorization header", str(context.exception))
+            self.assertIn(
+                "Missing or invalid Authorization header", str(context.exception)
+            )
 
     def test_authenticate_invalid_authorization_header(self):
         with patch("temba.conversion_events.jwt_auth.settings") as mock_settings:
@@ -979,7 +1061,9 @@ class JWTModuleAuthenticationTestCase(TestCase):
             request.headers = {"Authorization": "InvalidFormat"}
             with self.assertRaises(AuthenticationFailed) as context:
                 self.auth.authenticate(request)
-            self.assertIn("Missing or invalid Authorization header", str(context.exception))
+            self.assertIn(
+                "Missing or invalid Authorization header", str(context.exception)
+            )
 
     @patch("temba.conversion_events.jwt_auth.jwt.decode")
     @patch("temba.conversion_events.jwt_auth.settings")
@@ -990,7 +1074,10 @@ class JWTModuleAuthenticationTestCase(TestCase):
         request.headers = {"Authorization": "Bearer valid-token"}
         with self.assertRaises(AuthenticationFailed) as context:
             self.auth.authenticate(request)
-        self.assertIn("project_uuid or channel_uuid must be present in token payload.", str(context.exception))
+        self.assertIn(
+            "project_uuid or channel_uuid must be present in token payload.",
+            str(context.exception),
+        )
 
     @patch("temba.conversion_events.jwt_auth.jwt.decode")
     @patch("temba.conversion_events.jwt_auth.settings")
@@ -1029,7 +1116,9 @@ class JWTModuleAuthenticationTestCase(TestCase):
         self.assertIn("Invalid token", str(context.exception))
 
     def test_authenticate_verify_jwt_decode_called_correctly(self):
-        with patch("temba.conversion_events.jwt_auth.jwt.decode") as mock_jwt_decode, patch(
+        with patch(
+            "temba.conversion_events.jwt_auth.jwt.decode"
+        ) as mock_jwt_decode, patch(
             "temba.conversion_events.jwt_auth.settings"
         ) as mock_settings:
             mock_settings.JWT_PUBLIC_KEY = self.mock_public_key
@@ -1075,3 +1164,213 @@ class JWTModuleAuthMixinTestCase(TestCase):
         request = self.factory.get("/")
         view = DummyView(request)
         self.assertIsNone(view.jwt_payload)
+
+
+class CtwaReferralSourceModelTest(TembaTest):
+    def test_create_without_org_raises_integrity_error(self):
+        with transaction.atomic():
+            with self.assertRaises(IntegrityError):
+                CtwaReferralSource.objects.create(
+                    source_id="no-org",
+                    source_type=CtwaReferralSource.SOURCE_TYPE_AD,
+                )
+
+    def test_get_or_create_for_org_requires_org(self):
+        with self.assertRaises(ValueError):
+            CtwaReferralSource.get_or_create_for_org(
+                None, "ad-1", CtwaReferralSource.SOURCE_TYPE_AD
+            )
+
+    def test_same_source_allowed_for_different_orgs(self):
+        source_id = "shared-ad"
+        source_a, created_a = CtwaReferralSource.get_or_create_for_org(
+            self.org, source_id, CtwaReferralSource.SOURCE_TYPE_AD
+        )
+        source_b, created_b = CtwaReferralSource.get_or_create_for_org(
+            self.org2, source_id, CtwaReferralSource.SOURCE_TYPE_AD
+        )
+
+        self.assertTrue(created_a)
+        self.assertTrue(created_b)
+        self.assertNotEqual(source_a.id, source_b.id)
+        self.assertEqual(source_a.source_id, source_b.source_id)
+        self.assertEqual(source_a.org, self.org)
+        self.assertEqual(source_b.org, self.org2)
+
+    def test_same_org_source_id_and_type_is_rejected(self):
+        source_id = "dup-ad"
+        CtwaReferralSource.get_or_create_for_org(
+            self.org, source_id, CtwaReferralSource.SOURCE_TYPE_AD
+        )
+
+        with transaction.atomic():
+            with self.assertRaises(IntegrityError):
+                CtwaReferralSource.objects.create(
+                    org=self.org,
+                    source_id=source_id,
+                    source_type=CtwaReferralSource.SOURCE_TYPE_AD,
+                )
+
+    def test_get_or_create_for_org_returns_existing(self):
+        source, created = CtwaReferralSource.get_or_create_for_org(
+            self.org, "existing-ad", CtwaReferralSource.SOURCE_TYPE_POST
+        )
+        again, created_again = CtwaReferralSource.get_or_create_for_org(
+            self.org, "existing-ad", CtwaReferralSource.SOURCE_TYPE_POST
+        )
+
+        self.assertTrue(created)
+        self.assertFalse(created_again)
+        self.assertEqual(source.id, again.id)
+
+
+class CtwaReferralSourceBackfillTest(TembaTest):
+    def setUp(self):
+        super().setUp()
+        self.channel = self.create_channel("WAC", "Org1 Channel", "1111111111")
+        self.channel2 = self.create_channel(
+            "WAC", "Org2 Channel", "2222222222", org=self.org2
+        )
+
+    def test_org_ids_resolved_from_ctwa_channel(self):
+        source, _ = CtwaReferralSource.get_or_create_for_org(
+            self.org2, "ad-from-channel", CtwaReferralSource.SOURCE_TYPE_AD
+        )
+        create_test_ctwa(
+            ctwa_clid="clid-inherit",
+            channel_uuid=self.channel.uuid,
+            waba="waba",
+            contact_urn="whatsapp:1111111111",
+            referral_source=source,
+        )
+
+        org_map = org_ids_by_source_id([source.id], CTWA, Channel)
+        self.assertEqual(org_map[source.id], [self.org.id])
+
+        apply_orgs_to_source(
+            source, org_map[source.id], CtwaReferralSource, CTWA, Channel
+        )
+        source.refresh_from_db()
+        self.assertEqual(source.org_id, self.org.id)
+
+    def test_shared_source_is_cloned_and_ctwas_retargeted(self):
+        source, _ = CtwaReferralSource.get_or_create_for_org(
+            self.org, "shared-ad", CtwaReferralSource.SOURCE_TYPE_AD, headline="Hello"
+        )
+        ctwa_org1 = create_test_ctwa(
+            ctwa_clid="clid-org1",
+            channel_uuid=self.channel.uuid,
+            waba="waba1",
+            contact_urn="whatsapp:1111111111",
+            referral_source=source,
+        )
+        ctwa_org2 = create_test_ctwa(
+            ctwa_clid="clid-org2",
+            channel_uuid=self.channel2.uuid,
+            waba="waba2",
+            contact_urn="whatsapp:2222222222",
+            referral_source=source,
+        )
+
+        org_map = org_ids_by_source_id([source.id], CTWA, Channel)
+        self.assertEqual(set(org_map[source.id]), {self.org.id, self.org2.id})
+
+        apply_orgs_to_source(
+            source, org_map[source.id], CtwaReferralSource, CTWA, Channel
+        )
+
+        source.refresh_from_db()
+        ctwa_org1.refresh_from_db()
+        ctwa_org2.refresh_from_db()
+
+        clone = CtwaReferralSource.objects.exclude(id=source.id).get(
+            source_id="shared-ad", source_type=CtwaReferralSource.SOURCE_TYPE_AD
+        )
+        self.assertEqual(source.org_id, org_map[source.id][0])
+        self.assertEqual(clone.org_id, org_map[source.id][1])
+        self.assertEqual(clone.headline, "Hello")
+        self.assertEqual(
+            ctwa_org1.referral_source_id,
+            source.id if source.org_id == self.org.id else clone.id,
+        )
+        self.assertEqual(
+            ctwa_org2.referral_source_id,
+            clone.id if source.org_id == self.org.id else source.id,
+        )
+        self.assertNotEqual(ctwa_org1.referral_source_id, ctwa_org2.referral_source_id)
+
+    def test_backfill_processes_sources_and_clones_shared_orgs(self):
+        source, _ = CtwaReferralSource.get_or_create_for_org(
+            self.org, "batched-ad", CtwaReferralSource.SOURCE_TYPE_AD
+        )
+        create_test_ctwa(
+            ctwa_clid="clid-batch-1",
+            channel_uuid=self.channel.uuid,
+            waba="waba1",
+            contact_urn="whatsapp:1111111111",
+            referral_source=source,
+        )
+        create_test_ctwa(
+            ctwa_clid="clid-batch-2",
+            channel_uuid=self.channel2.uuid,
+            waba="waba2",
+            contact_urn="whatsapp:2222222222",
+            referral_source=source,
+        )
+
+        backfill_ctwa_referral_source_org(
+            CtwaReferralSource, CTWA, Channel, source_ids=[source.id]
+        )
+
+        self.assertEqual(
+            CtwaReferralSource.objects.filter(source_id="batched-ad").count(),
+            2,
+        )
+        self.assertEqual(
+            set(
+                CtwaReferralSource.objects.filter(source_id="batched-ad").values_list(
+                    "org_id", flat=True
+                )
+            ),
+            {self.org.id, self.org2.id},
+        )
+
+    def test_backfill_logs_when_org_cannot_be_resolved(self):
+        source, _ = CtwaReferralSource.get_or_create_for_org(
+            self.org, "orphan-ad", CtwaReferralSource.SOURCE_TYPE_AD
+        )
+
+        with self.assertLogs(
+            "temba.conversion_events.migrations.0004_backfill_ctwareferralsource_org",
+            level="WARNING",
+        ) as logs:
+            backfill_ctwa_referral_source_org(
+                CtwaReferralSource, CTWA, Channel, source_ids=[source.id]
+            )
+
+        self.assertTrue(any(f"id={source.id}" in message for message in logs.output))
+        source.refresh_from_db()
+        self.assertEqual(source.org_id, self.org.id)
+
+    def test_backfill_is_noop_when_all_sources_have_org(self):
+        CtwaReferralSource.get_or_create_for_org(
+            self.org, "has-org", CtwaReferralSource.SOURCE_TYPE_AD
+        )
+        backfill_ctwa_referral_source_org(CtwaReferralSource, CTWA, Channel)
+        self.assertEqual(
+            CtwaReferralSource.objects.filter(
+                source_id="has-org", org=self.org
+            ).count(),
+            1,
+        )
+
+    def test_org_ids_by_source_id_returns_empty_for_no_ids(self):
+        self.assertEqual(org_ids_by_source_id([], CTWA, Channel), {})
+
+    def test_apply_orgs_to_source_skips_empty_org_ids(self):
+        source, _ = CtwaReferralSource.get_or_create_for_org(
+            self.org, "unchanged-ad", CtwaReferralSource.SOURCE_TYPE_AD
+        )
+        apply_orgs_to_source(source, [], CtwaReferralSource, CTWA, Channel)
+        source.refresh_from_db()
+        self.assertEqual(source.org_id, self.org.id)

--- a/temba/conversion_events/tests.py
+++ b/temba/conversion_events/tests.py
@@ -25,7 +25,9 @@ from temba.tests import TembaTest
 _backfill = import_module("temba.conversion_events.migrations.0004_backfill_ctwareferralsource_org")
 apply_orgs_to_source = _backfill.apply_orgs_to_source
 backfill_ctwa_referral_source_org = _backfill.backfill_ctwa_referral_source_org
+delete_unresolved_sources = _backfill.delete_unresolved_sources
 org_channels_by_source_id = _backfill.org_channels_by_source_id
+resolve_batch_orgs = _backfill.resolve_batch_orgs
 
 
 def create_test_ctwa(**kwargs):
@@ -1319,6 +1321,7 @@ class CtwaReferralSourceBackfillTest(TembaTest):
         self.assertIn(f"id={source.id}", mock_warning.call_args[0][0])
         source.refresh_from_db()
         self.assertEqual(source.org_id, self.org.id)
+        self.assertTrue(CtwaReferralSource.objects.filter(id=source.id).exists())
 
     def test_backfill_is_noop_when_all_sources_have_org(self):
         CtwaReferralSource.get_or_create_for_org(self.org, "has-org", CtwaReferralSource.SOURCE_TYPE_AD)
@@ -1338,6 +1341,36 @@ class CtwaReferralSourceBackfillTest(TembaTest):
         apply_orgs_to_source(source, {}, CtwaReferralSource, CTWA)
         source.refresh_from_db()
         self.assertEqual(source.org_id, self.org.id)
+
+    def test_resolve_batch_orgs_reports_unresolved_null_org_sources(self):
+        source, _ = CtwaReferralSource.get_or_create_for_org(
+            self.org, "unresolved-null-org", CtwaReferralSource.SOURCE_TYPE_AD
+        )
+        standin = self._null_org_standin(source)
+
+        with patch.object(_backfill.logger, "warning") as mock_warning:
+            unresolved_ids = resolve_batch_orgs([standin], {}, CtwaReferralSource, CTWA)
+
+        self.assertEqual(unresolved_ids, [source.id])
+        mock_warning.assert_called_once()
+        self.assertIn(f"id={source.id}", mock_warning.call_args[0][0])
+
+    def test_delete_unresolved_sources_removes_source_and_its_ctwas(self):
+        source, _ = CtwaReferralSource.get_or_create_for_org(
+            self.org, "deletable-ad", CtwaReferralSource.SOURCE_TYPE_AD
+        )
+        ctwa = create_test_ctwa(
+            ctwa_clid="clid-deletable",
+            channel_uuid=self.channel.uuid,
+            waba="waba",
+            contact_urn="whatsapp:1111111111",
+            referral_source=source,
+        )
+
+        delete_unresolved_sources([source.id], CtwaReferralSource, CTWA)
+
+        self.assertFalse(CtwaReferralSource.objects.filter(id=source.id).exists())
+        self.assertFalse(CTWA.objects.filter(id=ctwa.id).exists())
 
     def test_forwards_loads_models_and_runs_backfill(self):
         apps = Mock()

--- a/temba/conversion_events/tests.py
+++ b/temba/conversion_events/tests.py
@@ -1254,15 +1254,15 @@ class CtwaReferralSourceBackfillTest(TembaTest):
         )
 
     def test_backfill_logs_when_org_cannot_be_resolved(self):
-        source, _ = CtwaReferralSource.get_or_create_for_org(self.org, "orphan-ad", CtwaReferralSource.SOURCE_TYPE_AD)
+        source, _ = CtwaReferralSource.get_or_create_for_org(
+            self.org, f"orphan-ad-{uuid4()}", CtwaReferralSource.SOURCE_TYPE_AD
+        )
 
-        with self.assertLogs(
-            "temba.conversion_events.migrations.0004_backfill_ctwareferralsource_org",
-            level="WARNING",
-        ) as logs:
+        with patch.object(_backfill.logger, "warning") as mock_warning:
             backfill_ctwa_referral_source_org(CtwaReferralSource, CTWA, Channel, source_ids=[source.id])
 
-        self.assertTrue(any(f"id={source.id}" in message for message in logs.output))
+        mock_warning.assert_called_once()
+        self.assertIn(f"id={source.id}", mock_warning.call_args[0][0])
         source.refresh_from_db()
         self.assertEqual(source.org_id, self.org.id)
 


### PR DESCRIPTION
## Changes

- Added a `ForeignKey` field for `org` in the `CtwaReferralSource` model to associate referral sources with organizations.
- Updated the unique constraint on `CtwaReferralSource` to include `org`, allowing the same `source_id` and `source_type` combination to exist across different organizations.
- Added a composite index on `org` and `last_seen_at` to support efficient per-org queries.
- Introduced a `get_or_create_for_org` class method on `CtwaReferralSource` that enforces org is always provided when creating referral sources.
- Implemented a backfill migration that resolves the org for each existing `CtwaReferralSource` by tracing its associated CTWA channels, cloning records and retargeting CTWAs when a source is shared across multiple organizations.
- Made the `org` field non-nullable after backfilling to enforce data integrity going forward.
- Added tests covering model-level constraints, the `get_or_create_for_org` method, backfill logic including shared-org cloning, orphaned source logging, and edge cases such as empty inputs.