### PR TITLE
feat: integrate CTWA events into contact detail view

### DIFF
--- a/temba/contacts/tests.py
+++ b/temba/contacts/tests.py
@@ -28,6 +28,7 @@ from temba.campaigns.models import Campaign, CampaignEvent, EventFire
 from temba.channels.models import Channel, ChannelEvent, ChannelLog
 from temba.contacts.search import SearchException, SearchResults, search_contacts
 from temba.contacts.views import ContactCRUDL, ContactGroupCRUDL, ContactGroupForm, ContactListView
+from temba.conversion_events.models import CTWA, CtwaReferralSource
 from temba.flows.models import Flow, FlowSession, FlowStart
 from temba.ivr.models import IVRCall
 from temba.locations.models import AdminBoundary
@@ -2802,6 +2803,8 @@ class ContactTest(TembaTest):
         # visit a contact detail page as a manager within the organization
         response = self.fetch_protected(read_url, self.admin)
         self.assertEqual(self.joe, response.context["object"])
+        self.assertIsNone(response.context["latest_ctwa_event"])
+        self.assertNotContains(response, 'id="contact-ctwa"')
 
         with patch("temba.orgs.models.Org.get_schemes") as mock_get_schemes:
             mock_get_schemes.return_value = []
@@ -2911,6 +2914,34 @@ class ContactTest(TembaTest):
             reverse("contacts.contact_read", args=[self.other_org_contact.uuid]), self.superuser
         )
         self.assertEqual(response.status_code, 200)
+
+    def test_read_latest_ctwa_event(self):
+        read_url = reverse("contacts.contact_read", args=[self.joe.uuid])
+        response = self.fetch_protected(read_url, self.admin)
+        self.assertIsNone(response.context["latest_ctwa_event"])
+        self.assertNotContains(response, 'id="contact-ctwa"')
+
+        source, _ = CtwaReferralSource.get_or_create_for_org(
+            self.org,
+            "120226305854810726",
+            CtwaReferralSource.SOURCE_TYPE_AD,
+            headline="Carrossel Tênis Running 30% OFF",
+            source_url="https://fb.me/2aBcDeFgHiJ",
+        )
+        CTWA.objects.create(
+            referral_source=source,
+            ctwa_clid="clid-joe",
+            channel_uuid=self.channel.uuid,
+            waba="waba-test",
+            contact_urn=self.joe.get_urn(URN.TEL_SCHEME).identity,
+            timestamp=timezone.now(),
+        )
+
+        response = self.fetch_protected(read_url, self.admin)
+        self.assertEqual(response.context["latest_ctwa_event"].ctwa_clid, "clid-joe")
+        self.assertContains(response, "Carrossel Tênis Running 30% OFF")
+        self.assertContains(response, "120226305854810726")
+        self.assertContains(response, "clid-joe")
 
     def test_read_with_customer_support(self):
         self.customer_support.is_staff = True

--- a/temba/contacts/views.py
+++ b/temba/contacts/views.py
@@ -37,6 +37,7 @@ from temba.archives.models import Archive
 from temba.channels.models import Channel
 from temba.contacts.templatetags.contacts import MISSING_VALUE
 from temba.contacts.validators import clean_contact_name, validate_contact_phone
+from temba.conversion_events.models import CTWA
 from temba.flows.models import Flow, FlowStart
 from temba.mailroom.events import Event
 from temba.notifications.views import NotificationTargetMixin
@@ -902,6 +903,8 @@ class ContactCRUDL(SmartCRUDL):
             context["open_tickets"] = list(
                 contact.tickets.filter(status=Ticket.STATUS_OPEN).select_related("ticketer").order_by("-opened_on")
             )
+
+            context["latest_ctwa_event"] = CTWA.objects.latest_for_contact(contact)
 
             # divide contact's URNs into those we can send to, and those we can't
             sendable_schemes = contact.org.get_schemes(Channel.ROLE_SEND)

--- a/temba/conversion_events/models.py
+++ b/temba/conversion_events/models.py
@@ -2,6 +2,8 @@ from django.db import models
 
 from temba.orgs.models import Org
 
+from .urns import whatsapp_urn_variants
+
 
 class CtwaReferralSource(models.Model):
     """
@@ -59,10 +61,29 @@ class CtwaReferralSource(models.Model):
         )
 
 
+class CTWAManager(models.Manager):
+    def latest_for_urns(self, *, channel_uuids, contact_urns):
+        return (
+            self.select_related("referral_source")
+            .filter(channel_uuid__in=channel_uuids, contact_urn__in=contact_urns)
+            .order_by("-timestamp")
+            .first()
+        )
+
+    def latest_for_contact(self, contact):
+        channel_uuids = list(contact.org.channels.filter(is_active=True).values_list("uuid", flat=True))
+        contact_urns = [variant for urn in contact.get_urns() for variant in whatsapp_urn_variants(urn.identity)]
+        if not channel_uuids or not contact_urns:
+            return None
+        return self.latest_for_urns(channel_uuids=channel_uuids, contact_urns=contact_urns)
+
+
 class CTWA(models.Model):
     """
     Click/conversation event with operational context for CTWA conversion lookup.
     """
+
+    objects = CTWAManager()
 
     ctwa_clid = models.CharField(
         max_length=512,

--- a/temba/conversion_events/tests.py
+++ b/temba/conversion_events/tests.py
@@ -1,5 +1,5 @@
 import json
-from datetime import datetime, timezone as dt_timezone
+from datetime import datetime, timedelta, timezone as dt_timezone
 from importlib import import_module
 from types import SimpleNamespace
 from unittest.mock import Mock, patch
@@ -21,6 +21,7 @@ from temba.channels.types.whatsapp_cloud.type import WhatsAppCloudType
 from temba.conversion_events.jwt_auth import JWTModuleAuthentication, JWTModuleAuthMixin
 from temba.conversion_events.models import CTWA, CtwaReferralSource
 from temba.conversion_events.serializers import ConversionEventSerializer
+from temba.conversion_events.urns import whatsapp_urn_variants
 from temba.tests import TembaTest
 
 _backfill = import_module("temba.conversion_events.migrations.0004_backfill_ctwareferralsource_org")
@@ -849,6 +850,26 @@ class ConversionEventAPITest(TembaTest):
                 mock_send_event.assert_called_once()
 
 
+class WhatsappUrnVariantsTest(TestCase):
+    def test_brazilian_with_extra_nine(self):
+        self.assertEqual(
+            whatsapp_urn_variants("whatsapp:5511912345678"),
+            ["whatsapp:5511912345678", "whatsapp:551112345678"],
+        )
+
+    def test_brazilian_without_extra_nine(self):
+        self.assertEqual(
+            whatsapp_urn_variants("whatsapp:551112345678"),
+            ["whatsapp:551112345678", "whatsapp:5511912345678"],
+        )
+
+    def test_non_brazilian_whatsapp(self):
+        self.assertEqual(whatsapp_urn_variants("whatsapp:14155551212"), ["whatsapp:14155551212"])
+
+    def test_non_whatsapp(self):
+        self.assertEqual(whatsapp_urn_variants("tel:+250781111111"), ["tel:+250781111111"])
+
+
 class CTWAModelTest(TembaTest):
     """Test the CTWA model"""
 
@@ -977,6 +998,65 @@ class CTWAModelTest(TembaTest):
         # Test with empty URN
         result = view._get_ctwa_data(self.channel.uuid, "")
         self.assertIsNone(result)
+
+    def test_latest_for_contact_returns_newest_event(self):
+        contact = self.create_contact(name="WA", urns=["whatsapp:5511912345678"])
+        create_test_ctwa(
+            ctwa_clid="old-clid",
+            channel_uuid=self.channel.uuid,
+            waba="waba",
+            contact_urn="whatsapp:5511912345678",
+            timestamp=timezone.now() - timedelta(hours=1),
+        )
+        newer = create_test_ctwa(
+            ctwa_clid="new-clid",
+            channel_uuid=self.channel.uuid,
+            waba="waba",
+            contact_urn="whatsapp:5511912345678",
+            timestamp=timezone.now(),
+        )
+
+        self.assertEqual(CTWA.objects.latest_for_contact(contact), newer)
+
+    def test_latest_for_contact_matches_brazilian_urn_variant(self):
+        contact = self.create_contact(name="WA", urns=["whatsapp:5511912345678"])
+        ctwa = create_test_ctwa(
+            ctwa_clid="br-clid",
+            channel_uuid=self.channel.uuid,
+            waba="waba",
+            contact_urn="whatsapp:551112345678",
+        )
+
+        self.assertEqual(CTWA.objects.latest_for_contact(contact), ctwa)
+
+    def test_latest_for_contact_returns_none_without_urns(self):
+        contact = self.create_contact(name="No URN")
+        self.assertIsNone(CTWA.objects.latest_for_contact(contact))
+
+    def test_latest_for_contact_returns_none_without_channels(self):
+        contact = self.create_contact(name="Org2", urns=["whatsapp:5511999999999"], org=self.org2)
+        create_test_ctwa(
+            org=self.org2,
+            ctwa_clid="org2-clid",
+            channel_uuid=uuid4(),
+            waba="waba",
+            contact_urn="whatsapp:5511999999999",
+        )
+
+        self.assertIsNone(CTWA.objects.latest_for_contact(contact))
+
+    def test_latest_for_contact_does_not_return_other_org_event(self):
+        contact = self.create_contact(name="WA", urns=["whatsapp:5511912345678"])
+        channel2 = self.create_channel("WAC", "Org2 Channel", "9999999999", org=self.org2)
+        create_test_ctwa(
+            org=self.org2,
+            ctwa_clid="other-org",
+            channel_uuid=channel2.uuid,
+            waba="waba",
+            contact_urn="whatsapp:5511912345678",
+        )
+
+        self.assertIsNone(CTWA.objects.latest_for_contact(contact))
 
 
 class CtwaDatalakeDualWriteTest(TembaTest):

--- a/temba/conversion_events/urns.py
+++ b/temba/conversion_events/urns.py
@@ -1,3 +1,10 @@
+BR_COUNTRY_CODE = "55"
+BR_DDD_LENGTH = 2
+BR_COUNTRY_AND_DDD_LENGTH = len(BR_COUNTRY_CODE) + BR_DDD_LENGTH
+BR_SUBSCRIBER_DIGITS_WITHOUT_NINE = 8
+BR_EXTRA_NINE = "9"
+
+
 def whatsapp_urn_variants(contact_urn: str) -> list:
     """Brazilian WhatsApp numbers are stored with or without the extra 9th
     digit depending on the source, so both spellings must be matched."""
@@ -5,13 +12,13 @@ def whatsapp_urn_variants(contact_urn: str) -> list:
         return [contact_urn]
 
     prefix, number = contact_urn.split(":", 1)
-    if not number.startswith("55"):
+    if not number.startswith(BR_COUNTRY_CODE):
         return [contact_urn]
 
-    remaining_digits = number[4:]
-    if len(remaining_digits) > 8:
-        other_number = number[:4] + remaining_digits[1:]
+    remaining_digits = number[BR_COUNTRY_AND_DDD_LENGTH:]
+    if len(remaining_digits) > BR_SUBSCRIBER_DIGITS_WITHOUT_NINE:
+        other_number = number[:BR_COUNTRY_AND_DDD_LENGTH] + remaining_digits[1:]
     else:
-        other_number = number[:4] + "9" + remaining_digits
+        other_number = number[:BR_COUNTRY_AND_DDD_LENGTH] + BR_EXTRA_NINE + remaining_digits
 
     return [f"{prefix}:{num}" for num in (number, other_number)]

--- a/temba/conversion_events/urns.py
+++ b/temba/conversion_events/urns.py
@@ -1,0 +1,17 @@
+def whatsapp_urn_variants(contact_urn: str) -> list:
+    """Brazilian WhatsApp numbers are stored with or without the extra 9th
+    digit depending on the source, so both spellings must be matched."""
+    if not contact_urn.startswith("whatsapp:"):
+        return [contact_urn]
+
+    prefix, number = contact_urn.split(":", 1)
+    if not number.startswith("55"):
+        return [contact_urn]
+
+    remaining_digits = number[4:]
+    if len(remaining_digits) > 8:
+        other_number = number[:4] + remaining_digits[1:]
+    else:
+        other_number = number[:4] + "9" + remaining_digits
+
+    return [f"{prefix}:{num}" for num in (number, other_number)]

--- a/temba/conversion_events/views.py
+++ b/temba/conversion_events/views.py
@@ -12,6 +12,7 @@ from django.http import JsonResponse
 from .courier_auth import ConversionEventAuthMixin
 from .models import CTWA
 from .serializers import ConversionEventSerializer
+from .urns import whatsapp_urn_variants
 
 COURIER_ONLY_EVENT_TYPES = {"conversation_started"}
 
@@ -163,42 +164,10 @@ class ConversionEventView(ConversionEventAuthMixin, viewsets.ModelViewSet):
     def _get_ctwa_data(self, channel_uuid, contact_urn):
         """Get CTWA data for lookup using both channel_uuid and contact_urn"""
         try:
-            base_qs = CTWA.objects.select_related("referral_source")
-
-            # If it's not a WhatsApp URN, just do a normal lookup
-            if not contact_urn.startswith("whatsapp:"):
-                return (
-                    base_qs.filter(channel_uuid=channel_uuid, contact_urn=contact_urn).order_by("-timestamp").first()
-                )
-
-            # For WhatsApp URNs, try both with and without the extra 9 if it's a Brazilian number
-            # Split the URN into prefix and number
-            prefix, number = contact_urn.split(":", 1)
-
-            # Only handle the extra 9 for Brazilian numbers
-            if number.startswith("55"):
-                # Remove country code (55) and DDD (2 digits) to check remaining length
-                remaining_digits = number[4:]  # After 55 + DDD
-
-                # If we have more than 8 digits after DDD, it means we have the extra 9
-                if len(remaining_digits) > 8:  # Has the extra 9
-                    # Generate version without the extra 9
-                    other_number = number[:4] + remaining_digits[1:]  # Remove first digit after DDD (the 9)
-                    numbers = [number, other_number]
-                else:  # Doesn't have the extra 9
-                    # Generate version with the extra 9
-                    other_number = number[:4] + "9" + remaining_digits  # Add 9 after DDD
-                    numbers = [number, other_number]
-
-                # Create both URNs for lookup
-                urns = [f"{prefix}:{num}" for num in numbers]
-
-                # Try to find CTWA data for either URN
-                return base_qs.filter(channel_uuid=channel_uuid, contact_urn__in=urns).order_by("-timestamp").first()
-
-            # For non-BR numbers or if we can't handle the number format, just do a normal lookup
-            return base_qs.filter(channel_uuid=channel_uuid, contact_urn=contact_urn).order_by("-timestamp").first()
-
+            return CTWA.objects.latest_for_urns(
+                channel_uuids=[channel_uuid],
+                contact_urns=whatsapp_urn_variants(contact_urn),
+            )
         except Exception as e:
             logger.error(f"Error fetching CTWA data: {str(e)}")
             return None

--- a/templates/contacts/contact_read.haml
+++ b/templates/contacts/contact_read.haml
@@ -152,6 +152,57 @@
                 -else
                   {{urn|format_urn:user_org}}      
 
+  -if latest_ctwa_event
+    %table.list.tight.toggle.stateful.mt-6#contact-ctwa
+      %thead
+        %th(colspan="2")
+          {{ latest_ctwa_event.referral_source.headline|default:"--" }}
+      %tbody
+        %tr
+          %td
+            .whitespace-nowrap.pr-24.contact-field
+              .contact-field-value.uppercase.tracking-wider.font-normal.text-xs
+                -trans "Source Headline"
+          %td.w-full
+            .contact-field-value
+              {{ latest_ctwa_event.referral_source.headline|default:"--" }}
+        %tr
+          %td
+            .whitespace-nowrap.pr-24.contact-field
+              .contact-field-value.uppercase.tracking-wider.font-normal.text-xs
+                -trans "Source ID"
+          %td.w-full
+            .contact-field-value
+              {{ latest_ctwa_event.referral_source.source_id }}
+        %tr
+          %td
+            .whitespace-nowrap.pr-24.contact-field
+              .contact-field-value.uppercase.tracking-wider.font-normal.text-xs
+                -trans "Source URL"
+          %td.w-full
+            .contact-field-value
+              -if latest_ctwa_event.referral_source.source_url
+                %a.linked{href:"{{ latest_ctwa_event.referral_source.source_url }}", target:"_blank", rel:"noopener noreferrer"}
+                  {{ latest_ctwa_event.referral_source.source_url }}
+              -else
+                {{ "--" }}
+        %tr
+          %td
+            .whitespace-nowrap.pr-24.contact-field
+              .contact-field-value.uppercase.tracking-wider.font-normal.text-xs
+                -trans "CTWA CLID"
+          %td.w-full
+            .contact-field-value
+              {{ latest_ctwa_event.ctwa_clid|default:"--" }}
+        %tr
+          %td
+            .whitespace-nowrap.pr-24.contact-field
+              .contact-field-value.uppercase.tracking-wider.font-normal.text-xs
+                -trans "Timestamp"
+          %td.w-full
+            .contact-field-value
+              {% format_datetime latest_ctwa_event.timestamp %}
+
   -if open_tickets
     %table.list.tickets.mt-6
       %thead
@@ -260,6 +311,10 @@
       .page-content {
         align-self: auto;
         max-width: 1024px;
+      }
+
+      #contact-ctwa thead th {
+        text-transform: none;
       }
 
     {% lessblock %}


### PR DESCRIPTION
## Changes

- Added a `CTWAManager` to the `CTWA` model with `latest_for_urns` and `latest_for_contact` methods to retrieve the most recent CTWA event for a contact based on their URNs and the org's active channels.
- Extracted Brazilian WhatsApp number variant logic into a dedicated `whatsapp_urn_variants` utility function in `urns.py`, replacing duplicated inline logic in the conversion events view.
- Exposed `latest_ctwa_event` in the contact read view context so the template can conditionally render CTWA details.
- Updated the contact detail template to display a CTWA section showing the source headline, source ID, source URL, CTWA CLID, and timestamp when a matching event exists.
- Added tests covering `whatsapp_urn_variants` for Brazilian numbers with and without the extra 9th digit, non-Brazilian WhatsApp numbers, and non-WhatsApp URNs.
- Added tests for `CTWAManager.latest_for_contact` verifying correct ordering, Brazilian URN variant matching, and isolation across orgs and channels.
- Added tests to the contact read view asserting that `latest_ctwa_event` is `None` and the CTWA section is absent when no event exists, and that the correct event data is rendered when one is present.