### PR TITLE
feat: collapse legacy CTWA referral sources into single canonical row per org

### DIFF
--- a/temba/api/v2/internals/conversion_events/tests/test_usecases.py
+++ b/temba/api/v2/internals/conversion_events/tests/test_usecases.py
@@ -99,9 +99,7 @@ class ListCtwaReferralSourcesUseCaseTest(TembaTest):
         self.assertEqual(results, [valid])
 
     def test_execute_includes_legacy_source_id_when_type_is_post(self):
-        post = self._create_source(
-            self.org, CtwaReferralSource.LEGACY_SOURCE_ID, CtwaReferralSource.SOURCE_TYPE_POST
-        )
+        post = self._create_source(self.org, CtwaReferralSource.LEGACY_SOURCE_ID, CtwaReferralSource.SOURCE_TYPE_POST)
 
         dto = ListCtwaReferralSourcesDTO(project_uuid=str(self.org.proj_uuid))
         results = list(self.usecase.execute(dto))

--- a/temba/api/v2/internals/conversion_events/tests/test_usecases.py
+++ b/temba/api/v2/internals/conversion_events/tests/test_usecases.py
@@ -88,3 +88,22 @@ class ListCtwaReferralSourcesUseCaseTest(TembaTest):
         self.assertEqual(results, [inside])
         self.assertNotIn(before_range, results)
         self.assertNotIn(after_range, results)
+
+    def test_execute_excludes_legacy_ad_placeholder(self):
+        valid = self._create_source(self.org, "real-ad")
+        self._create_source(self.org, CtwaReferralSource.LEGACY_SOURCE_ID, CtwaReferralSource.SOURCE_TYPE_AD)
+
+        dto = ListCtwaReferralSourcesDTO(project_uuid=str(self.org.proj_uuid))
+        results = list(self.usecase.execute(dto))
+
+        self.assertEqual(results, [valid])
+
+    def test_execute_includes_legacy_source_id_when_type_is_post(self):
+        post = self._create_source(
+            self.org, CtwaReferralSource.LEGACY_SOURCE_ID, CtwaReferralSource.SOURCE_TYPE_POST
+        )
+
+        dto = ListCtwaReferralSourcesDTO(project_uuid=str(self.org.proj_uuid))
+        results = list(self.usecase.execute(dto))
+
+        self.assertEqual(results, [post])

--- a/temba/api/v2/internals/conversion_events/usecases.py
+++ b/temba/api/v2/internals/conversion_events/usecases.py
@@ -31,7 +31,14 @@ class ListCtwaReferralSourcesUseCase:
             f"source_type={dto.source_type} after={dto.after} before={dto.before}"
         )
         org = self._get_org(dto.project_uuid)
-        queryset = CtwaReferralSource.objects.filter(org=org).select_related("org")
+        queryset = (
+            CtwaReferralSource.objects.filter(org=org)
+            .exclude(
+                source_id=CtwaReferralSource.LEGACY_SOURCE_ID,
+                source_type=CtwaReferralSource.SOURCE_TYPE_AD,
+            )
+            .select_related("org")
+        )
 
         if dto.source_type:
             queryset = queryset.filter(source_type=dto.source_type)

--- a/temba/conversion_events/migrations/0006_collapse_legacy_ctwa_referral_sources.py
+++ b/temba/conversion_events/migrations/0006_collapse_legacy_ctwa_referral_sources.py
@@ -22,9 +22,7 @@ def legacy_sources(CtwaReferralSource):
 
 
 def org_ids_with_legacy_sources(CtwaReferralSource):
-    return list(
-        legacy_sources(CtwaReferralSource).values_list("org_id", flat=True).distinct().order_by("org_id")
-    )
+    return list(legacy_sources(CtwaReferralSource).values_list("org_id", flat=True).distinct().order_by("org_id"))
 
 
 def preserve_seen_window(canonical_id, first_seen_at, last_seen_at, CtwaReferralSource):
@@ -84,16 +82,12 @@ def collapse_org_legacy_sources(org_id, CtwaReferralSource, CTWA, batch_size):
     repointed = 0
     max_id = 0
     while True:
-        chunk = list(
-            sources_qs.filter(id__gt=max_id).order_by("id").values_list("id", flat=True)[:batch_size]
-        )
+        chunk = list(sources_qs.filter(id__gt=max_id).order_by("id").values_list("id", flat=True)[:batch_size])
         if not chunk:
             break
 
         with transaction.atomic():
-            repointed += CTWA.objects.filter(referral_source_id__in=chunk).update(
-                referral_source_id=canonical.id
-            )
+            repointed += CTWA.objects.filter(referral_source_id__in=chunk).update(referral_source_id=canonical.id)
             CtwaReferralSource.objects.filter(id__in=chunk).delete()
 
         max_id = chunk[-1]

--- a/temba/conversion_events/migrations/0006_collapse_legacy_ctwa_referral_sources.py
+++ b/temba/conversion_events/migrations/0006_collapse_legacy_ctwa_referral_sources.py
@@ -3,7 +3,7 @@
 import logging
 
 from django.db import migrations, transaction
-from django.db.models import Max, Min
+from django.db.models import Count, Max, Min
 
 logger = logging.getLogger(__name__)
 
@@ -54,28 +54,32 @@ def collapse_org_legacy_sources(org_id, CtwaReferralSource, CTWA, batch_size):
     leftover source rows can be deleted.
     """
     sources_qs = legacy_sources(CtwaReferralSource).filter(org_id=org_id)
-    if not sources_qs.exists():
+    window = sources_qs.aggregate(
+        Min("first_seen_at"),
+        Max("last_seen_at"),
+        Count("id"),
+    )
+    collapsed_count = window["id__count"]
+    if not collapsed_count:
         return
 
-    window = sources_qs.aggregate(Min("first_seen_at"), Max("last_seen_at"))
-    collapsed_count = sources_qs.count()
+    with transaction.atomic():
+        canonical, created = CtwaReferralSource.objects.get_or_create(
+            org_id=org_id,
+            source_id=LEGACY_SOURCE_ID,
+            source_type=LEGACY_SOURCE_TYPE,
+            defaults={
+                "source_url": None,
+                "headline": None,
+                "body": None,
+            },
+        )
 
-    canonical, created = CtwaReferralSource.objects.get_or_create(
-        org_id=org_id,
-        source_id=LEGACY_SOURCE_ID,
-        source_type=LEGACY_SOURCE_TYPE,
-        defaults={
-            "source_url": None,
-            "headline": None,
-            "body": None,
-        },
-    )
-
-    first_seen_at = window["first_seen_at__min"]
-    last_seen_at = window["last_seen_at__max"]
-    if not created:
-        first_seen_at, last_seen_at = _merged_seen_window(canonical, first_seen_at, last_seen_at)
-    preserve_seen_window(canonical.id, first_seen_at, last_seen_at, CtwaReferralSource)
+        first_seen_at = window["first_seen_at__min"]
+        last_seen_at = window["last_seen_at__max"]
+        if not created:
+            first_seen_at, last_seen_at = _merged_seen_window(canonical, first_seen_at, last_seen_at)
+        preserve_seen_window(canonical.id, first_seen_at, last_seen_at, CtwaReferralSource)
 
     repointed = 0
     max_id = 0

--- a/temba/conversion_events/migrations/0006_collapse_legacy_ctwa_referral_sources.py
+++ b/temba/conversion_events/migrations/0006_collapse_legacy_ctwa_referral_sources.py
@@ -1,0 +1,126 @@
+# Generated manually: collapse 0002 1:1 leftover sources into one "legacy" row per org
+
+import logging
+
+from django.db import migrations, transaction
+from django.db.models import Max, Min
+
+logger = logging.getLogger(__name__)
+
+BATCH_SIZE = 1000
+LEGACY_SOURCE_ID = "legacy"
+LEGACY_SOURCE_TYPE = "ad"
+# POSIX character class: PostgreSQL's ~ operator does not treat \d as digits.
+LEGACY_SOURCE_ID_PATTERN = r"^legacy-[0-9]+$"
+
+
+def legacy_sources(CtwaReferralSource):
+    return CtwaReferralSource.objects.filter(
+        source_type=LEGACY_SOURCE_TYPE,
+        source_id__regex=LEGACY_SOURCE_ID_PATTERN,
+    )
+
+
+def org_ids_with_legacy_sources(CtwaReferralSource):
+    return list(
+        legacy_sources(CtwaReferralSource).values_list("org_id", flat=True).distinct().order_by("org_id")
+    )
+
+
+def preserve_seen_window(canonical_id, first_seen_at, last_seen_at, CtwaReferralSource):
+    """Write the aggregated window with update() so auto_now does not overwrite it."""
+    updates = {}
+    if first_seen_at is not None:
+        updates["first_seen_at"] = first_seen_at
+    if last_seen_at is not None:
+        updates["last_seen_at"] = last_seen_at
+    if not updates:
+        return
+    CtwaReferralSource.objects.filter(id=canonical_id).update(**updates)
+
+
+def _merged_seen_window(canonical, first_seen_at, last_seen_at):
+    if canonical.first_seen_at is not None and (first_seen_at is None or canonical.first_seen_at < first_seen_at):
+        first_seen_at = canonical.first_seen_at
+    if canonical.last_seen_at is not None and (last_seen_at is None or canonical.last_seen_at > last_seen_at):
+        last_seen_at = canonical.last_seen_at
+    return first_seen_at, last_seen_at
+
+
+def collapse_org_legacy_sources(org_id, CtwaReferralSource, CTWA, batch_size):
+    """Repoint this org's 0002 leftover sources onto a single canonical row.
+
+    CTWA.referral_source is PROTECT, so events must be retargeted before the
+    leftover source rows can be deleted.
+    """
+    sources_qs = legacy_sources(CtwaReferralSource).filter(org_id=org_id)
+    if not sources_qs.exists():
+        return
+
+    window = sources_qs.aggregate(Min("first_seen_at"), Max("last_seen_at"))
+    collapsed_count = sources_qs.count()
+
+    canonical, created = CtwaReferralSource.objects.get_or_create(
+        org_id=org_id,
+        source_id=LEGACY_SOURCE_ID,
+        source_type=LEGACY_SOURCE_TYPE,
+        defaults={
+            "source_url": None,
+            "headline": None,
+            "body": None,
+        },
+    )
+
+    first_seen_at = window["first_seen_at__min"]
+    last_seen_at = window["last_seen_at__max"]
+    if not created:
+        first_seen_at, last_seen_at = _merged_seen_window(canonical, first_seen_at, last_seen_at)
+    preserve_seen_window(canonical.id, first_seen_at, last_seen_at, CtwaReferralSource)
+
+    repointed = 0
+    max_id = 0
+    while True:
+        chunk = list(
+            sources_qs.filter(id__gt=max_id).order_by("id").values_list("id", flat=True)[:batch_size]
+        )
+        if not chunk:
+            break
+
+        with transaction.atomic():
+            repointed += CTWA.objects.filter(referral_source_id__in=chunk).update(
+                referral_source_id=canonical.id
+            )
+            CtwaReferralSource.objects.filter(id__in=chunk).delete()
+
+        max_id = chunk[-1]
+
+    logger.info(
+        f"Collapsed {collapsed_count} legacy CtwaReferralSource rows into canonical id={canonical.id} "
+        f"for org_id={org_id}, repointed {repointed} CTWA events"
+    )
+
+
+def collapse_legacy_sources_per_org(CtwaReferralSource, CTWA, batch_size=BATCH_SIZE, org_ids=None):
+    if org_ids is None:
+        org_ids = org_ids_with_legacy_sources(CtwaReferralSource)
+    for org_id in org_ids:
+        collapse_org_legacy_sources(org_id, CtwaReferralSource, CTWA, batch_size)
+
+
+def forwards(apps, schema_editor):
+    CtwaReferralSource = apps.get_model("conversion_events", "CtwaReferralSource")
+    CTWA = apps.get_model("conversion_events", "CTWA")
+    collapse_legacy_sources_per_org(CtwaReferralSource, CTWA)
+
+
+class Migration(migrations.Migration):
+
+    atomic = False
+
+    dependencies = [
+        ("conversion_events", "0005_ctwareferralsource_org_not_null"),
+    ]
+
+    operations = [
+        migrations.RunPython(forwards, migrations.RunPython.noop),
+    ]

--- a/temba/conversion_events/models.py
+++ b/temba/conversion_events/models.py
@@ -16,6 +16,7 @@ class CtwaReferralSource(models.Model):
         (SOURCE_TYPE_AD, "Ad"),
         (SOURCE_TYPE_POST, "Post"),
     )
+    LEGACY_SOURCE_ID = "legacy"
 
     org = models.ForeignKey(Org, on_delete=models.PROTECT, related_name="ctwa_referral_sources")
     source_id = models.CharField(max_length=64)

--- a/temba/conversion_events/tests.py
+++ b/temba/conversion_events/tests.py
@@ -31,6 +31,13 @@ delete_unresolved_sources = _backfill.delete_unresolved_sources
 org_channels_by_source_id = _backfill.org_channels_by_source_id
 resolve_batch_orgs = _backfill.resolve_batch_orgs
 
+_collapse = import_module("temba.conversion_events.migrations.0006_collapse_legacy_ctwa_referral_sources")
+collapse_legacy_sources_per_org = _collapse.collapse_legacy_sources_per_org
+collapse_org_legacy_sources = _collapse.collapse_org_legacy_sources
+legacy_sources = _collapse.legacy_sources
+org_ids_with_legacy_sources = _collapse.org_ids_with_legacy_sources
+preserve_seen_window = _collapse.preserve_seen_window
+
 
 def create_test_ctwa(**kwargs):
     referral_source = kwargs.pop("referral_source", None)
@@ -1778,3 +1785,268 @@ class CtwaReferralSourceBackfillTest(TembaTest):
             _backfill.forwards(apps, schema_editor=None)
 
         mock_backfill.assert_called_once_with(CtwaReferralSource, CTWA, Channel)
+
+
+class CtwaReferralSourceCollapseTest(TembaTest):
+    def setUp(self):
+        super().setUp()
+        self.channel = self.create_channel("WAC", "Org1 Channel", "1111111111")
+        self.channel2 = self.create_channel("WAC", "Org2 Channel", "2222222222", org=self.org2)
+
+    def _create_legacy_source(self, org, ctwa_id, first_seen_at=None, last_seen_at=None):
+        source = CtwaReferralSource.objects.create(
+            org=org,
+            source_id=f"legacy-{ctwa_id}",
+            source_type=CtwaReferralSource.SOURCE_TYPE_AD,
+        )
+        updates = {}
+        if first_seen_at is not None:
+            updates["first_seen_at"] = first_seen_at
+        if last_seen_at is not None:
+            updates["last_seen_at"] = last_seen_at
+        if updates:
+            CtwaReferralSource.objects.filter(id=source.id).update(**updates)
+            source.refresh_from_db()
+        return source
+
+    def _create_legacy_ctwa(self, *, org, channel, ctwa_id, clid):
+        source = self._create_legacy_source(org, ctwa_id)
+        ctwa = create_test_ctwa(
+            ctwa_clid=clid,
+            channel_uuid=channel.uuid,
+            waba="waba",
+            contact_urn="whatsapp:1111111111",
+            referral_source=source,
+        )
+        return source, ctwa
+
+    def test_collapse_merges_legacy_sources_in_one_org(self):
+        source_a, ctwa_a = self._create_legacy_ctwa(org=self.org, channel=self.channel, ctwa_id=11, clid="clid-a")
+        source_b, ctwa_b = self._create_legacy_ctwa(org=self.org, channel=self.channel, ctwa_id=12, clid="clid-b")
+
+        collapse_legacy_sources_per_org(CtwaReferralSource, CTWA)
+
+        canonical = CtwaReferralSource.objects.get(
+            org=self.org, source_id="legacy", source_type=CtwaReferralSource.SOURCE_TYPE_AD
+        )
+        ctwa_a.refresh_from_db()
+        ctwa_b.refresh_from_db()
+
+        self.assertEqual(ctwa_a.referral_source_id, canonical.id)
+        self.assertEqual(ctwa_b.referral_source_id, canonical.id)
+        self.assertFalse(CtwaReferralSource.objects.filter(id__in=[source_a.id, source_b.id]).exists())
+        self.assertEqual(
+            CtwaReferralSource.objects.filter(org=self.org, source_id="legacy").count(),
+            1,
+        )
+
+    def test_collapse_keeps_a_canonical_source_per_org(self):
+        _, ctwa_org1 = self._create_legacy_ctwa(org=self.org, channel=self.channel, ctwa_id=21, clid="clid-org1")
+        _, ctwa_org2 = self._create_legacy_ctwa(org=self.org2, channel=self.channel2, ctwa_id=22, clid="clid-org2")
+
+        collapse_legacy_sources_per_org(CtwaReferralSource, CTWA)
+
+        canonical_org1 = CtwaReferralSource.objects.get(org=self.org, source_id="legacy")
+        canonical_org2 = CtwaReferralSource.objects.get(org=self.org2, source_id="legacy")
+        ctwa_org1.refresh_from_db()
+        ctwa_org2.refresh_from_db()
+
+        self.assertNotEqual(canonical_org1.id, canonical_org2.id)
+        self.assertEqual(ctwa_org1.referral_source_id, canonical_org1.id)
+        self.assertEqual(ctwa_org2.referral_source_id, canonical_org2.id)
+
+    def test_collapse_leaves_non_legacy_and_near_miss_sources(self):
+        real, _ = CtwaReferralSource.get_or_create_for_org(self.org, "real-ad-123", CtwaReferralSource.SOURCE_TYPE_AD)
+        near_miss, _ = CtwaReferralSource.get_or_create_for_org(
+            self.org, "legacy-abc", CtwaReferralSource.SOURCE_TYPE_AD
+        )
+        post_legacy, _ = CtwaReferralSource.get_or_create_for_org(
+            self.org, "legacy-99", CtwaReferralSource.SOURCE_TYPE_POST
+        )
+        self._create_legacy_ctwa(org=self.org, channel=self.channel, ctwa_id=31, clid="clid-keep")
+
+        collapse_legacy_sources_per_org(CtwaReferralSource, CTWA)
+
+        self.assertTrue(CtwaReferralSource.objects.filter(id=real.id).exists())
+        self.assertTrue(CtwaReferralSource.objects.filter(id=near_miss.id).exists())
+        self.assertTrue(CtwaReferralSource.objects.filter(id=post_legacy.id).exists())
+        self.assertTrue(
+            CtwaReferralSource.objects.filter(org=self.org, source_id="legacy", source_type="ad").exists()
+        )
+
+    def test_canonical_inherits_earliest_first_seen_and_latest_last_seen(self):
+        early = timezone.now() - timedelta(days=10)
+        middle = timezone.now() - timedelta(days=5)
+        late = timezone.now() - timedelta(days=1)
+
+        source_early = self._create_legacy_source(self.org, 41, first_seen_at=early, last_seen_at=middle)
+        source_late = self._create_legacy_source(self.org, 42, first_seen_at=middle, last_seen_at=late)
+        create_test_ctwa(
+            ctwa_clid="clid-window-early",
+            channel_uuid=self.channel.uuid,
+            waba="waba",
+            contact_urn="whatsapp:1111111111",
+            referral_source=source_early,
+        )
+        create_test_ctwa(
+            ctwa_clid="clid-window-late",
+            channel_uuid=self.channel.uuid,
+            waba="waba",
+            contact_urn="whatsapp:1111111111",
+            referral_source=source_late,
+        )
+
+        collapse_legacy_sources_per_org(CtwaReferralSource, CTWA)
+
+        canonical = CtwaReferralSource.objects.get(org=self.org, source_id="legacy")
+        self.assertEqual(canonical.first_seen_at, early)
+        self.assertEqual(canonical.last_seen_at, late)
+
+    def test_collapse_merges_window_into_existing_canonical(self):
+        existing_first = timezone.now() - timedelta(days=20)
+        existing_last = timezone.now() - timedelta(days=8)
+        leftover_first = timezone.now() - timedelta(days=3)
+        leftover_last = timezone.now() - timedelta(days=1)
+
+        canonical, _ = CtwaReferralSource.get_or_create_for_org(
+            self.org, "legacy", CtwaReferralSource.SOURCE_TYPE_AD
+        )
+        CtwaReferralSource.objects.filter(id=canonical.id).update(
+            first_seen_at=existing_first, last_seen_at=existing_last
+        )
+
+        leftover = self._create_legacy_source(
+            self.org, 51, first_seen_at=leftover_first, last_seen_at=leftover_last
+        )
+        create_test_ctwa(
+            ctwa_clid="clid-existing-canonical",
+            channel_uuid=self.channel.uuid,
+            waba="waba",
+            contact_urn="whatsapp:1111111111",
+            referral_source=leftover,
+        )
+
+        collapse_legacy_sources_per_org(CtwaReferralSource, CTWA, org_ids=[self.org.id])
+
+        canonical.refresh_from_db()
+        self.assertEqual(canonical.first_seen_at, existing_first)
+        self.assertEqual(canonical.last_seen_at, leftover_last)
+
+    def test_collapse_is_idempotent(self):
+        _, ctwa = self._create_legacy_ctwa(org=self.org, channel=self.channel, ctwa_id=61, clid="clid-once")
+
+        collapse_legacy_sources_per_org(CtwaReferralSource, CTWA)
+        canonical_id = CtwaReferralSource.objects.get(org=self.org, source_id="legacy").id
+        collapse_legacy_sources_per_org(CtwaReferralSource, CTWA)
+
+        ctwa.refresh_from_db()
+        self.assertEqual(
+            CtwaReferralSource.objects.filter(org=self.org, source_id="legacy").count(),
+            1,
+        )
+        self.assertEqual(ctwa.referral_source_id, canonical_id)
+
+    def test_collapse_with_batch_size_one_processes_all_chunks(self):
+        created = [
+            self._create_legacy_ctwa(org=self.org, channel=self.channel, ctwa_id=ctwa_id, clid=f"clid-batch-{ctwa_id}")
+            for ctwa_id in (71, 72, 73)
+        ]
+
+        collapse_legacy_sources_per_org(CtwaReferralSource, CTWA, batch_size=1)
+
+        canonical = CtwaReferralSource.objects.get(org=self.org, source_id="legacy")
+        for source, ctwa in created:
+            ctwa.refresh_from_db()
+            self.assertEqual(ctwa.referral_source_id, canonical.id)
+            self.assertFalse(CtwaReferralSource.objects.filter(id=source.id).exists())
+
+    def test_collapse_skips_org_without_legacy_sources(self):
+        collapse_org_legacy_sources(self.org.id, CtwaReferralSource, CTWA, batch_size=1000)
+        self.assertFalse(CtwaReferralSource.objects.filter(org=self.org, source_id="legacy").exists())
+
+    def test_org_ids_narrowing_collapses_only_the_requested_org(self):
+        self._create_legacy_ctwa(org=self.org, channel=self.channel, ctwa_id=81, clid="clid-narrow-1")
+        source_org2, _ = self._create_legacy_ctwa(
+            org=self.org2, channel=self.channel2, ctwa_id=82, clid="clid-narrow-2"
+        )
+
+        collapse_legacy_sources_per_org(CtwaReferralSource, CTWA, org_ids=[self.org.id])
+
+        self.assertTrue(CtwaReferralSource.objects.filter(org=self.org, source_id="legacy").exists())
+        self.assertTrue(CtwaReferralSource.objects.filter(id=source_org2.id).exists())
+        self.assertFalse(CtwaReferralSource.objects.filter(org=self.org2, source_id="legacy").exists())
+
+    def test_preserve_seen_window_skips_when_both_values_are_none(self):
+        canonical, _ = CtwaReferralSource.get_or_create_for_org(
+            self.org, "legacy", CtwaReferralSource.SOURCE_TYPE_AD
+        )
+        original_first = canonical.first_seen_at
+        original_last = canonical.last_seen_at
+
+        preserve_seen_window(canonical.id, None, None, CtwaReferralSource)
+
+        canonical.refresh_from_db()
+        self.assertEqual(canonical.first_seen_at, original_first)
+        self.assertEqual(canonical.last_seen_at, original_last)
+
+    def test_preserve_seen_window_updates_only_provided_fields(self):
+        canonical, _ = CtwaReferralSource.get_or_create_for_org(
+            self.org, "legacy", CtwaReferralSource.SOURCE_TYPE_AD
+        )
+        original_last = canonical.last_seen_at
+        new_first = timezone.now() - timedelta(days=15)
+
+        preserve_seen_window(canonical.id, new_first, None, CtwaReferralSource)
+
+        canonical.refresh_from_db()
+        self.assertEqual(canonical.first_seen_at, new_first)
+        self.assertEqual(canonical.last_seen_at, original_last)
+
+    def test_merged_seen_window_picks_earliest_first_and_latest_last(self):
+        earlier = timezone.now() - timedelta(days=10)
+        later = timezone.now() - timedelta(days=1)
+        canonical = SimpleNamespace(first_seen_at=earlier, last_seen_at=later)
+
+        first_seen_at, last_seen_at = _collapse._merged_seen_window(canonical, later, earlier)
+
+        self.assertEqual(first_seen_at, earlier)
+        self.assertEqual(last_seen_at, later)
+
+    def test_merged_seen_window_keeps_aggregated_values_when_canonical_has_none(self):
+        stamp = timezone.now() - timedelta(days=2)
+        canonical = SimpleNamespace(first_seen_at=None, last_seen_at=None)
+
+        first_seen_at, last_seen_at = _collapse._merged_seen_window(canonical, stamp, stamp)
+
+        self.assertEqual(first_seen_at, stamp)
+        self.assertEqual(last_seen_at, stamp)
+
+    def test_merged_seen_window_uses_canonical_when_aggregated_is_none(self):
+        stamp = timezone.now() - timedelta(days=2)
+        canonical = SimpleNamespace(first_seen_at=stamp, last_seen_at=stamp)
+
+        first_seen_at, last_seen_at = _collapse._merged_seen_window(canonical, None, None)
+
+        self.assertEqual(first_seen_at, stamp)
+        self.assertEqual(last_seen_at, stamp)
+
+    def test_org_ids_with_legacy_sources_returns_distinct_orgs(self):
+        self._create_legacy_source(self.org, 91)
+        self._create_legacy_source(self.org, 92)
+        self._create_legacy_source(self.org2, 93)
+
+        self.assertEqual(org_ids_with_legacy_sources(CtwaReferralSource), [self.org.id, self.org2.id])
+        self.assertEqual(legacy_sources(CtwaReferralSource).count(), 3)
+
+    def test_forwards_loads_models_and_runs_collapse(self):
+        apps = Mock()
+        models = {
+            ("conversion_events", "CtwaReferralSource"): CtwaReferralSource,
+            ("conversion_events", "CTWA"): CTWA,
+        }
+        apps.get_model.side_effect = lambda app, model: models[(app, model)]
+
+        with patch.object(_collapse, "collapse_legacy_sources_per_org") as mock_collapse:
+            _collapse.forwards(apps, schema_editor=None)
+
+        mock_collapse.assert_called_once_with(CtwaReferralSource, CTWA)

--- a/temba/conversion_events/tests.py
+++ b/temba/conversion_events/tests.py
@@ -1870,9 +1870,7 @@ class CtwaReferralSourceCollapseTest(TembaTest):
         self.assertTrue(CtwaReferralSource.objects.filter(id=real.id).exists())
         self.assertTrue(CtwaReferralSource.objects.filter(id=near_miss.id).exists())
         self.assertTrue(CtwaReferralSource.objects.filter(id=post_legacy.id).exists())
-        self.assertTrue(
-            CtwaReferralSource.objects.filter(org=self.org, source_id="legacy", source_type="ad").exists()
-        )
+        self.assertTrue(CtwaReferralSource.objects.filter(org=self.org, source_id="legacy", source_type="ad").exists())
 
     def test_canonical_inherits_earliest_first_seen_and_latest_last_seen(self):
         early = timezone.now() - timedelta(days=10)
@@ -1908,16 +1906,12 @@ class CtwaReferralSourceCollapseTest(TembaTest):
         leftover_first = timezone.now() - timedelta(days=3)
         leftover_last = timezone.now() - timedelta(days=1)
 
-        canonical, _ = CtwaReferralSource.get_or_create_for_org(
-            self.org, "legacy", CtwaReferralSource.SOURCE_TYPE_AD
-        )
+        canonical, _ = CtwaReferralSource.get_or_create_for_org(self.org, "legacy", CtwaReferralSource.SOURCE_TYPE_AD)
         CtwaReferralSource.objects.filter(id=canonical.id).update(
             first_seen_at=existing_first, last_seen_at=existing_last
         )
 
-        leftover = self._create_legacy_source(
-            self.org, 51, first_seen_at=leftover_first, last_seen_at=leftover_last
-        )
+        leftover = self._create_legacy_source(self.org, 51, first_seen_at=leftover_first, last_seen_at=leftover_last)
         create_test_ctwa(
             ctwa_clid="clid-existing-canonical",
             channel_uuid=self.channel.uuid,
@@ -1977,9 +1971,7 @@ class CtwaReferralSourceCollapseTest(TembaTest):
         self.assertFalse(CtwaReferralSource.objects.filter(org=self.org2, source_id="legacy").exists())
 
     def test_preserve_seen_window_skips_when_both_values_are_none(self):
-        canonical, _ = CtwaReferralSource.get_or_create_for_org(
-            self.org, "legacy", CtwaReferralSource.SOURCE_TYPE_AD
-        )
+        canonical, _ = CtwaReferralSource.get_or_create_for_org(self.org, "legacy", CtwaReferralSource.SOURCE_TYPE_AD)
         original_first = canonical.first_seen_at
         original_last = canonical.last_seen_at
 
@@ -1990,9 +1982,7 @@ class CtwaReferralSourceCollapseTest(TembaTest):
         self.assertEqual(canonical.last_seen_at, original_last)
 
     def test_preserve_seen_window_updates_only_provided_fields(self):
-        canonical, _ = CtwaReferralSource.get_or_create_for_org(
-            self.org, "legacy", CtwaReferralSource.SOURCE_TYPE_AD
-        )
+        canonical, _ = CtwaReferralSource.get_or_create_for_org(self.org, "legacy", CtwaReferralSource.SOURCE_TYPE_AD)
         original_last = canonical.last_seen_at
         new_first = timezone.now() - timedelta(days=15)
 


### PR DESCRIPTION
## Changes

- Updated `ListCtwaReferralSourcesUseCase` to exclude `CtwaReferralSource` entries where `source_id` is `"legacy"` and `source_type` is `"ad"`, while still returning legacy entries with `source_type` of `"post"`.
- Added unit tests to verify that the legacy ad placeholder is excluded from query results and that legacy sources with a post type are correctly included.
- Introduced migration `0006_collapse_legacy_ctwa_referral_sources` to consolidate per-org `legacy-{id}` referral source rows (created by migration `0002`) into a single canonical `"legacy"` row per organization, retargeting associated `CTWA` events and preserving the earliest `first_seen_at` and latest `last_seen_at` across all collapsed rows.
- Added `LEGACY_SOURCE_ID = "legacy"` constant to `CtwaReferralSource` for consistent reference across the codebase.
- Added comprehensive tests covering merging behavior, idempotency, batch processing, org isolation, seen-window aggregation, and the migration's `forwards` function.