### PR TITLE
fix: add `break-all` to CTWA contact fields to prevent overflow

### DIFF
--- a/templates/contacts/contact_read.haml
+++ b/templates/contacts/contact_read.haml
@@ -164,7 +164,7 @@
               .contact-field-value.uppercase.tracking-wider.font-normal.text-xs
                 -trans "Source Headline"
           %td.w-full
-            .contact-field-value
+            .break-all.contact-field-value
               {{ latest_ctwa_event.referral_source.headline|default:"--" }}
         %tr
           %td
@@ -172,7 +172,7 @@
               .contact-field-value.uppercase.tracking-wider.font-normal.text-xs
                 -trans "Source ID"
           %td.w-full
-            .contact-field-value
+            .break-all.contact-field-value
               {{ latest_ctwa_event.referral_source.source_id }}
         %tr
           %td
@@ -180,7 +180,7 @@
               .contact-field-value.uppercase.tracking-wider.font-normal.text-xs
                 -trans "Source URL"
           %td.w-full
-            .contact-field-value
+            .break-all.contact-field-value
               -if latest_ctwa_event.referral_source.source_url
                 %a.linked{href:"{{ latest_ctwa_event.referral_source.source_url }}", target:"_blank", rel:"noopener noreferrer"}
                   {{ latest_ctwa_event.referral_source.source_url }}
@@ -192,7 +192,7 @@
               .contact-field-value.uppercase.tracking-wider.font-normal.text-xs
                 -trans "CTWA CLID"
           %td.w-full
-            .contact-field-value
+            .break-all.contact-field-value
               {{ latest_ctwa_event.ctwa_clid|default:"--" }}
         %tr
           %td
@@ -200,7 +200,7 @@
               .contact-field-value.uppercase.tracking-wider.font-normal.text-xs
                 -trans "Timestamp"
           %td.w-full
-            .contact-field-value
+            .break-all.contact-field-value
               {% format_datetime latest_ctwa_event.timestamp %}
 
   -if open_tickets


### PR DESCRIPTION
### TL;DR

Added `break-all` CSS class to CTWA event fields in the contact read template to prevent layout overflow.

### What changed?

The `break-all` Tailwind CSS class was added to the contact field value containers for the following CTWA referral fields: Source Headline, Source ID, Source URL, CTWA CLID, and Timestamp.

### How to test?

1. Open a contact that has an associated CTWA event with long values in the referral source fields (e.g., a lengthy URL or CLID).
2. Verify that the text wraps within its container rather than overflowing or breaking the layout.

### Why make this change?

Long strings such as URLs, CLIDs, or source IDs could overflow their table cells, causing layout issues on the contact read page. Applying `break-all` ensures these values wrap correctly regardless of their length.