### PR TITLE
feat: increase flow start params string limit from 640 to 4096

### DIFF
--- a/WENI-CHANGELOG.md
+++ b/WENI-CHANGELOG.md
@@ -1,3 +1,8 @@
+3.94.1
+----------
+* feat: increase flow start params string limit from 640 to 4096
+* fix: add break-all to CTWA contact fields to prevent overflow
+
 3.94.0
 ----------
 * feat: add search functionality to ListCtwaReferralSource API

--- a/temba/api/v2/serializers.py
+++ b/temba/api/v2/serializers.py
@@ -65,7 +65,7 @@ def _normalize_extra(extra, count):
         return INVALID_EXTRA_KEY_CHARS.sub("_", key)[:255]
 
     if isinstance(extra, str):
-        return extra[:640], count + 1
+        return extra[: settings.FLOW_START_PARAM_VALUE_SIZE], count + 1
 
     elif isinstance(extra, numbers.Number) or isinstance(extra, bool):
         return extra, count + 1

--- a/temba/api/v2/tests.py
+++ b/temba/api/v2/tests.py
@@ -422,7 +422,7 @@ class APITest(APIJSONMixin, TembaTest):
             serializers.ValidationError, field.to_internal_value, {"eng": "HelloHello1"}
         )  # base lang not provided
 
-    @override_settings(FLOW_START_PARAMS_SIZE=4)
+    @override_settings(FLOW_START_PARAMS_SIZE=4, FLOW_START_PARAM_VALUE_SIZE=640)
     def test_normalize_extra(self):
         self.assertEqual(OrderedDict(), normalize_extra({}))
         self.assertEqual(
@@ -438,6 +438,12 @@ class APITest(APIJSONMixin, TembaTest):
             normalize_extra({"a": 1, "b": 2, "c": 3, "d": 4, "e": 5}),
         )
         self.assertEqual(OrderedDict([("a", "x" * 640)]), normalize_extra({"a": "x" * 641}))
+
+    def test_normalize_extra_param_value_size_default(self):
+        size = settings.FLOW_START_PARAM_VALUE_SIZE
+        self.assertEqual(4096, size)
+        self.assertEqual(OrderedDict([("a", "x" * size)]), normalize_extra({"a": "x" * size}))
+        self.assertEqual(OrderedDict([("a", "x" * size)]), normalize_extra({"a": "x" * (size + 1)}))
 
     def test_authentication(self):
         def request(endpoint, **headers):

--- a/temba/api/v2/views.py
+++ b/temba/api/v2/views.py
@@ -613,7 +613,7 @@ class BroadcastsEndpoint(ListAPIMixin, WriteAPIMixin, BaseAPIView):
 
     A `POST` allows you to create and send new broadcasts, with the following JSON data:
 
-      * **text** - the text of the message to send (string, limited to 640 characters)
+      * **text** - the text of the message to send (string, limited to 1500 characters)
       * **urns** - the URNs of contacts to send to (array of up to 1000 strings, optional)
       * **contacts** - the UUIDs of contacts to send to (array of up to 1000 strings, optional)
       * **groups** - the UUIDs of contact groups to send to (array of up to 100 strings, optional)
@@ -4610,7 +4610,7 @@ class FlowStartsEndpoint(ListAPIMixin, WriteAPIMixin, BaseAPIView):
      * **urns** - the URNs you want to start in this flow (array of up to 100 strings, optional)
      * **restart_participants** - whether to restart participants already in this flow (optional, defaults to true)
      * **exclude_active** - whether to exclude contacts currently in other flow (optional, defaults to false)
-     * **params** - a dictionary of extra parameters to pass to the flow start (accessible via @trigger.params in your flow)
+     * **params** - a dictionary of extra parameters to pass to the flow start (accessible via @trigger.params in your flow, string values limited to 4096 characters)
 
     Example:
 

--- a/temba/settings_common.py
+++ b/temba/settings_common.py
@@ -1417,6 +1417,9 @@ IP_ADDRESSES = ("172.16.10.10", "162.16.10.20")
 # -----------------------------------------------------------------------------------
 MSG_FIELD_SIZE = os.environ.get("MSG_FIELD_SIZE", 1500)  # used for broadcast text and message campaign events
 FLOW_START_PARAMS_SIZE = 256  # used for params passed to flow start API endpoint
+FLOW_START_PARAM_VALUE_SIZE = int(
+    os.environ.get("FLOW_START_PARAM_VALUE_SIZE", 4096)
+)  # max length of each string in flow start params
 GLOBAL_VALUE_SIZE = 10_000  # max length of global values
 
 ORG_LIMIT_DEFAULTS = {


### PR DESCRIPTION
@trigger.params values were silently truncated at 640 characters, cutting
Odoo messages sent via WhatsApp. Align the per-value cap with the WhatsApp
Cloud API text limit and make it configurable via FLOW_START_PARAM_VALUE_SIZE.