### PR TITLE
feat: Add Live Desk Copilot WWC channel on project creation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+v7.1.28
+----------
+ * Add Live Desk Copilot WWC channel auto-creation when project is created with is_live_desk_copilot flag
+
 v7.1.27
 ----------
  * Drop no longer used FlowRun.parent

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "temba"
-version = "7.1.27"
+version = "7.1.28"
 description = "Hosted service for visually building interactive messaging applications"
 authors = ["Nyaruka <code@nyaruka.com>"]
 license = "AGPL-3"

--- a/temba/channels/tests.py
+++ b/temba/channels/tests.py
@@ -1624,6 +1624,25 @@ class ChannelCRUDLTest(TembaTest, CRUDLTestMixin):
         response = self.assertDeleteSubmit(delete_url, object_deactivated=vonage, success_status=200)
         self.assertEqual(f"/channels/channel/read/{android.uuid}/", response["Temba-Success"])
 
+    def test_update_and_delete_hidden_copilot_channel(self):
+        copilot_channel = self.create_channel(
+            "WWC",
+            "Weni Web Chat - Copilot",
+            "copilot-address",
+            config={"is_live_desk_copilot": True},
+        )
+
+        update_url = reverse("channels.channel_update", args=[copilot_channel.id])
+        delete_url = reverse("channels.channel_delete", args=[copilot_channel.uuid])
+
+        self.login(self.admin)
+
+        response = self.client.get(update_url)
+        self.assertEqual(response.status_code, 404)
+
+        response = self.client.get(delete_url)
+        self.assertEqual(response.status_code, 404)
+
 
 class ChannelEventCRUDLTest(TembaTest):
     def test_calls(self):

--- a/temba/channels/views.py
+++ b/temba/channels/views.py
@@ -44,6 +44,7 @@ from temba.orgs.views import AnonMixin, DependencyDeleteModal, MenuMixin, ModalM
 from temba.utils import analytics, countries, json
 from temba.utils.fields import SelectWidget
 from temba.utils.models import patch_queryset_count
+from temba.projects.usecases.channel_creation import is_hidden_from_ui
 from temba.utils.views import ComponentFormMixin, SpaMixin
 
 from .models import (
@@ -747,6 +748,8 @@ class ChannelCRUDL(SmartCRUDL):
 
                 channels = Channel.objects.filter(org=org, is_active=True, parent=None).order_by("-role")
                 for channel in channels:
+                    if is_hidden_from_ui(channel):
+                        continue
                     icon = channel.get_type().icon.replace("icon-", "")
                     icon = icon.replace("power-cord", "box")
 
@@ -813,7 +816,9 @@ class ChannelCRUDL(SmartCRUDL):
                         )
                     )
 
-            if self.has_org_perm("channels.channel_update"):
+            channel_is_hidden = is_hidden_from_ui(self.object)
+
+            if self.has_org_perm("channels.channel_update") and not channel_is_hidden:
                 links.append(
                     dict(
                         id="update-channel",
@@ -863,7 +868,7 @@ class ChannelCRUDL(SmartCRUDL):
                             )
                         )
 
-            if self.has_org_perm("channels.channel_delete"):
+            if self.has_org_perm("channels.channel_delete") and not channel_is_hidden:
                 links.append(
                     dict(
                         id="delete-channel",
@@ -1131,6 +1136,12 @@ class ChannelCRUDL(SmartCRUDL):
             "If you do not need this number you can delete it from the Twilio website."
         )
 
+        def get_object(self, queryset=None):
+            channel = super().get_object(queryset)
+            if is_hidden_from_ui(channel):
+                raise Http404()
+            return channel
+
         def get_success_url(self):
             # if we're deleting a child channel, redirect to parent afterwards
             channel = self.get_object()
@@ -1179,6 +1190,12 @@ class ChannelCRUDL(SmartCRUDL):
     class Update(OrgObjPermsMixin, ComponentFormMixin, ModalMixin, SmartUpdateView):
         success_message = ""
         submit_button_name = _("Save Changes")
+
+        def get_object(self, queryset=None):
+            channel = super().get_object(queryset)
+            if is_hidden_from_ui(channel):
+                raise Http404()
+            return channel
 
         def derive_title(self):
             return _("%s Channel") % self.object.get_channel_type_display()
@@ -1411,7 +1428,9 @@ class ChannelCRUDL(SmartCRUDL):
                 org = self.request.user.get_org()
                 queryset = queryset.filter(org=org)
 
-            return queryset.filter(is_active=True)
+            queryset = queryset.filter(is_active=True)
+            hidden_ids = [channel.pk for channel in queryset if is_hidden_from_ui(channel)]
+            return queryset.exclude(pk__in=hidden_ids)
 
         def pre_process(self, *args, **kwargs):
             # superuser sees things as they are
@@ -1420,7 +1439,11 @@ class ChannelCRUDL(SmartCRUDL):
 
             # everybody else goes to a different page depending how many channels there are
             org = self.request.user.get_org()
-            channels = list(Channel.objects.filter(org=org, is_active=True))
+            channels = [
+                channel
+                for channel in Channel.objects.filter(org=org, is_active=True)
+                if not is_hidden_from_ui(channel)
+            ]
 
             if len(channels) == 0:
                 return HttpResponseRedirect(reverse("channels.channel_claim"))

--- a/temba/orgs/tests.py
+++ b/temba/orgs/tests.py
@@ -2528,6 +2528,23 @@ class OrgTest(TembaTest):
         self.assertContains(response, self.channel.name)
         self.assertNotContains(response, preview_channel.name)
 
+    def test_home_hides_copilot_channels(self):
+        self.login(self.admin)
+
+        copilot_channel = self.create_channel(
+            "WWC",
+            "Weni Web Chat - Copilot",
+            "copilot-channel",
+            org=self.org,
+            config={"is_live_desk_copilot": True},
+        )
+
+        response = self.client.get(reverse("orgs.org_home"))
+
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, self.channel.name)
+        self.assertNotContains(response, copilot_channel.name)
+
     @patch("temba.channels.types.vonage.client.VonageClient.check_credentials")
     def test_connect_vonage(self, mock_check_credentials):
         self.login(self.admin)

--- a/temba/orgs/views.py
+++ b/temba/orgs/views.py
@@ -59,6 +59,7 @@ from django.views.generic import View
 from temba.api.models import APIToken, Resthook
 from temba.campaigns.models import Campaign
 from temba.channels.models import Channel
+from temba.projects.usecases.channel_creation import is_hidden_from_ui
 from temba.classifiers.models import Classifier
 from temba.contacts.models import ContactGroupCount
 from temba.flows.models import Flow
@@ -3253,7 +3254,7 @@ class OrgCRUDL(SmartCRUDL):
                 # get any channel thats not a delegate
                 channels = Channel.objects.filter(org=org, is_active=True, parent=None).order_by("-role")
                 for channel in channels:
-                    if channel.config.get("preview") is True:
+                    if is_hidden_from_ui(channel):
                         continue
                     self.add_channel_section(formax, channel)
 

--- a/temba/projects/consumers/project_consumer.py
+++ b/temba/projects/consumers/project_consumer.py
@@ -4,7 +4,11 @@ from weni.eda.messages import Message
 
 from temba.projects.usecases.project_creation import ProjectCreationUseCase
 
-from ..usecases import FlowSetupHandlerUseCase, ProjectCreationDTO, TemplateTypeIntegrationUseCase
+from ..usecases import (
+    FlowSetupHandlerUseCase,
+    ProjectCreationDTO,
+    TemplateTypeIntegrationUseCase,
+)
 
 
 class ProjectEventType:
@@ -36,11 +40,15 @@ class ProjectConsumer(EDAConsumer):
             brain_on=body.get("brain_on", False),
             language=body.get("language"),
             inline_agent_switch=body.get("inline_agent_switch", True),
+            is_live_desk_copilot=body.get("is_live_desk_copilot", False),
         )
 
         flow_setup_handler = FlowSetupHandlerUseCase()
         template_type_integration = TemplateTypeIntegrationUseCase(flow_setup_handler)
         project_creation = ProjectCreationUseCase(template_type_integration)
         project_creation.create_project(
-            project_dto, body.get("user_email"), body.get("extra_fields"), body.get("authorizations")
+            project_dto,
+            body.get("user_email"),
+            body.get("extra_fields"),
+            body.get("authorizations"),
         )

--- a/temba/projects/consumers/tests/test_project_consumer.py
+++ b/temba/projects/consumers/tests/test_project_consumer.py
@@ -52,12 +52,51 @@ class TestProjectConsumer(TembaTest):
         consumer.consume(message)
 
         mock_use_case.create_project.assert_called_once()
-        project_dto, user_email, extra_fields, authorizations = mock_use_case.create_project.call_args[0]
+        (
+            project_dto,
+            user_email,
+            extra_fields,
+            authorizations,
+        ) = mock_use_case.create_project.call_args[0]
         self.assertEqual(user_email, "admin@example.com")
         self.assertEqual(extra_fields, {})
         self.assertEqual(authorizations, [])
         self.assertEqual(project_dto.language, "pt-br")
         self.assertTrue(project_dto.inline_agent_switch)
+        self.assertFalse(project_dto.is_live_desk_copilot)
+        channel.basic_ack.assert_called_once_with(message.delivery_tag)
+
+    @patch("temba.projects.consumers.project_consumer.ProjectCreationUseCase")
+    @patch("temba.projects.consumers.project_consumer.TemplateTypeIntegrationUseCase")
+    @patch("temba.projects.consumers.project_consumer.FlowSetupHandlerUseCase")
+    def test_consume_passes_is_live_desk_copilot_to_use_case(
+        self, mock_flow_uc, mock_template_uc, mock_project_creation_uc
+    ):
+        mock_use_case = Mock()
+        mock_project_creation_uc.return_value = mock_use_case
+
+        body = {
+            "uuid": str(uuid.uuid4()),
+            "name": "Test Project",
+            "is_template": False,
+            "date_format": "D",
+            "template_type_uuid": "",
+            "timezone": "Africa/Kigali",
+            "description": "desc",
+            "brain_on": False,
+            "is_live_desk_copilot": True,
+            "user_email": "admin@example.com",
+            "extra_fields": {},
+            "authorizations": [],
+        }
+        message, channel = self._create_message(body)
+        consumer = ProjectConsumer()
+        consumer._message = message
+
+        consumer.consume(message)
+
+        project_dto = mock_use_case.create_project.call_args[0][0]
+        self.assertTrue(project_dto.is_live_desk_copilot)
         channel.basic_ack.assert_called_once_with(message.delivery_tag)
 
     @patch("temba.projects.consumers.project_consumer.ProjectCreationUseCase")
@@ -95,7 +134,9 @@ class TestProjectConsumer(TembaTest):
     @patch("temba.projects.consumers.project_consumer.ProjectCreationUseCase")
     @patch("temba.projects.consumers.project_consumer.TemplateTypeIntegrationUseCase")
     @patch("temba.projects.consumers.project_consumer.FlowSetupHandlerUseCase")
-    def test_consume_ignores_unsupported_event_type(self, mock_flow_uc, mock_template_uc, mock_project_creation_uc):
+    def test_consume_ignores_unsupported_event_type(
+        self, mock_flow_uc, mock_template_uc, mock_project_creation_uc
+    ):
         mock_use_case = Mock()
         mock_project_creation_uc.return_value = mock_use_case
 

--- a/temba/projects/usecases/channel_creation.py
+++ b/temba/projects/usecases/channel_creation.py
@@ -4,11 +4,46 @@ from temba.channels.models import Channel
 from temba.projects.usecases.channel_publisher import publish_channel_event
 
 DEFAULT_WWC_CHANNEL_NAME = "Weni Web Chat - Preview"
+COPILOT_WWC_CHANNEL_NAME = "Weni Web Chat - Copilot"
+
+
+def is_hidden_from_ui(channel: Channel) -> bool:
+    config = channel.config or {}
+    return bool(config.get("preview")) or bool(config.get("is_live_desk_copilot"))
+
+
+def _get_wwc_channel_by_config_flag(org, flag_key: str) -> Channel | None:
+    for channel in Channel.objects.filter(org=org, channel_type="WWC"):
+        if channel.config and channel.config.get(flag_key):
+            return channel
+    return None
+
+
+def _build_default_wwc_config(
+    preview: bool = False, is_live_desk_copilot: bool = False
+) -> dict:
+    config = {
+        "version": 2,
+        "allowed_domains": settings.WENI_WEBCHAT_ALLOWED_DOMAINS,
+        "base_url": settings.SOCKET_BASE_URL,
+        "voice_mode": {
+            "enabled": True,
+            "elevenLabs": {
+                "apiKey": settings.WENI_VOICE_TOKEN,
+                "voiceId": settings.WENI_ELEVENLABS_VOICE_ID,
+            },
+        },
+    }
+    if preview:
+        config["preview"] = True
+    if is_live_desk_copilot:
+        config["is_live_desk_copilot"] = True
+    return config
 
 
 def create_default_wwc_channel(project, user) -> Channel:
-    existing_channel = Channel.objects.filter(org=project.org, channel_type="WWC").first()
-    if existing_channel and existing_channel.config.get("preview"):
+    existing_channel = _get_wwc_channel_by_config_flag(project.org, "preview")
+    if existing_channel:
         return existing_channel
 
     channel = Channel.create(
@@ -18,16 +53,27 @@ def create_default_wwc_channel(project, user) -> Channel:
         channel_type="WWC",
         name=DEFAULT_WWC_CHANNEL_NAME,
         address=str(project.project_uuid),
-        config={
-            "preview": True,
-            "version": 2,
-            "allowed_domains": settings.WENI_WEBCHAT_ALLOWED_DOMAINS,
-            "base_url": settings.SOCKET_BASE_URL,
-            "voice_mode": {
-                "enabled": True,
-                "elevenLabs": {"apiKey": settings.WENI_VOICE_TOKEN, "voiceId": settings.WENI_ELEVENLABS_VOICE_ID},
-            },
-        },
+        config=_build_default_wwc_config(preview=True),
+    )
+    publish_channel_event(channel, action="create")
+    return channel
+
+
+def create_live_desk_copilot_channel(project, user) -> Channel:
+    existing_channel = _get_wwc_channel_by_config_flag(
+        project.org, "is_live_desk_copilot"
+    )
+    if existing_channel:
+        return existing_channel
+
+    channel = Channel.create(
+        org=project.org,
+        user=user,
+        country=None,
+        channel_type="WWC",
+        name=COPILOT_WWC_CHANNEL_NAME,
+        address=f"{project.project_uuid}-copilot",
+        config=_build_default_wwc_config(is_live_desk_copilot=True),
     )
     publish_channel_event(channel, action="create")
     return channel

--- a/temba/projects/usecases/channel_publisher.py
+++ b/temba/projects/usecases/channel_publisher.py
@@ -11,6 +11,9 @@ def publish_channel_event(channel: Channel, action: str):
             uuid=str(channel.uuid),
             project_uuid=str(channel.org.proj_uuid),
             channel_type=channel.channel_type,
+            is_live_desk_copilot=bool(
+                (channel.config or {}).get("is_live_desk_copilot")
+            ),
         ),
         exchange="channel-events.topic",
         routing_key="wwc-create",

--- a/temba/projects/usecases/project_creation.py
+++ b/temba/projects/usecases/project_creation.py
@@ -7,7 +7,10 @@ from weni.internal.models import Project
 from django.contrib.auth import get_user_model
 
 from temba.projects.usecases.authorizations_creation import create_authorizations
-from temba.projects.usecases.channel_creation import create_default_wwc_channel
+from temba.projects.usecases.channel_creation import (
+    create_default_wwc_channel,
+    create_live_desk_copilot_channel,
+)
 from temba.projects.usecases.globals_creation import create_globals
 
 from .interfaces import TemplateTypeIntegrationInterface
@@ -27,6 +30,7 @@ class ProjectCreationDTO:
     brain_on: bool
     language: Optional[str] = None
     inline_agent_switch: bool = False
+    is_live_desk_copilot: bool = False
 
 
 class ProjectCreationUseCase:
@@ -62,7 +66,11 @@ class ProjectCreationUseCase:
         )
 
     def create_project(
-        self, project_dto: ProjectCreationDTO, user_email: str, extra_fields: dict, authorizations: list
+        self,
+        project_dto: ProjectCreationDTO,
+        user_email: str,
+        extra_fields: dict,
+        authorizations: list,
     ) -> None:
         user, _ = self.get_or_create_user_by_email(user_email)  # pragma: no cover
         project, _ = self.get_or_create_project(project_dto, user)
@@ -71,6 +79,9 @@ class ProjectCreationUseCase:
         project.initialize(sample_flows=False)
         project.save()
         create_default_wwc_channel(project, user)
+
+        if project_dto.is_live_desk_copilot:
+            create_live_desk_copilot_channel(project, user)
 
         if extra_fields:
             create_globals(extra_fields, project, user)

--- a/temba/projects/usecases/tests/test_channel_creation.py
+++ b/temba/projects/usecases/tests/test_channel_creation.py
@@ -1,0 +1,26 @@
+from temba.projects.usecases.channel_creation import is_hidden_from_ui
+from temba.tests.base import TembaTest
+
+
+class ChannelCreationTestCase(TembaTest):
+    def test_is_hidden_from_ui_for_preview_channel(self):
+        channel = self.create_channel(
+            "WWC", "Weni Web Chat - Preview", "preview", config={"preview": True}
+        )
+
+        self.assertTrue(is_hidden_from_ui(channel))
+
+    def test_is_hidden_from_ui_for_copilot_channel(self):
+        channel = self.create_channel(
+            "WWC",
+            "Weni Web Chat - Copilot",
+            "copilot",
+            config={"is_live_desk_copilot": True},
+        )
+
+        self.assertTrue(is_hidden_from_ui(channel))
+
+    def test_is_hidden_from_ui_for_regular_channel(self):
+        channel = self.create_channel("TG", "Telegram", "telegram")
+
+        self.assertFalse(is_hidden_from_ui(channel))

--- a/temba/projects/usecases/tests/test_channel_publisher.py
+++ b/temba/projects/usecases/tests/test_channel_publisher.py
@@ -7,7 +7,12 @@ from temba.tests.base import TembaTest
 class ChannelPublisherTestCase(TembaTest):
     @patch("temba.projects.usecases.channel_publisher.RabbitmqPublisher")
     def test_publish_channel_event(self, mock_rabbitmq_publisher):
-        channel = self.create_channel("WWC", "Weni Web Chat - Preview", "project-address", config={"preview": True})
+        channel = self.create_channel(
+            "WWC",
+            "Weni Web Chat - Preview",
+            "project-address",
+            config={"preview": True},
+        )
 
         publish_channel_event(channel, "create")
 
@@ -17,6 +22,32 @@ class ChannelPublisherTestCase(TembaTest):
                 "uuid": str(channel.uuid),
                 "project_uuid": str(channel.org.proj_uuid),
                 "channel_type": "WWC",
+                "is_live_desk_copilot": False,
+            },
+            exchange="channel-events.topic",
+            routing_key="wwc-create",
+        )
+
+    @patch("temba.projects.usecases.channel_publisher.RabbitmqPublisher")
+    def test_publish_channel_event_with_live_desk_copilot(
+        self, mock_rabbitmq_publisher
+    ):
+        channel = self.create_channel(
+            "WWC",
+            "Weni Web Chat - Copilot",
+            "project-address-copilot",
+            config={"is_live_desk_copilot": True},
+        )
+
+        publish_channel_event(channel, "create")
+
+        mock_rabbitmq_publisher.return_value.send_message.assert_called_once_with(
+            body={
+                "action": "create",
+                "uuid": str(channel.uuid),
+                "project_uuid": str(channel.org.proj_uuid),
+                "channel_type": "WWC",
+                "is_live_desk_copilot": True,
             },
             exchange="channel-events.topic",
             routing_key="wwc-create",

--- a/temba/projects/usecases/tests/test_project_creation.py
+++ b/temba/projects/usecases/tests/test_project_creation.py
@@ -6,15 +6,23 @@ import pytz
 from django.conf import settings
 
 from temba.channels.models import Channel
-from temba.projects.usecases.channel_creation import DEFAULT_WWC_CHANNEL_NAME
-from temba.projects.usecases.project_creation import ProjectCreationDTO, ProjectCreationUseCase
+from temba.projects.usecases.channel_creation import (
+    COPILOT_WWC_CHANNEL_NAME,
+    DEFAULT_WWC_CHANNEL_NAME,
+)
+from temba.projects.usecases.project_creation import (
+    ProjectCreationDTO,
+    ProjectCreationUseCase,
+)
 from temba.tests.base import TembaTest
 
 
 class ProjectCreationUseCaseTest(TembaTest):
     @patch("temba.projects.usecases.project_creation.ConnectInternalClient")
     @patch("temba.projects.usecases.channel_creation.publish_channel_event")
-    def test_create_project_creates_default_wwc_channel(self, mock_publish_channel_event, mock_connect_client):
+    def test_create_project_creates_default_wwc_channel(
+        self, mock_publish_channel_event, mock_connect_client
+    ):
         user_email = "new-project-admin@example.com"
         project_uuid = uuid.uuid4()
         project_dto = ProjectCreationDTO(
@@ -30,7 +38,9 @@ class ProjectCreationUseCaseTest(TembaTest):
 
         use_case = ProjectCreationUseCase(template_type_integration=Mock())
 
-        use_case.create_project(project_dto, user_email, extra_fields={}, authorizations=[])
+        use_case.create_project(
+            project_dto, user_email, extra_fields={}, authorizations=[]
+        )
 
         project = self.project.__class__.objects.get(project_uuid=project_uuid)
         channel = Channel.objects.get(org=project.org, channel_type="WWC")
@@ -80,9 +90,13 @@ class ProjectCreationUseCaseTest(TembaTest):
 
         use_case = ProjectCreationUseCase(template_type_integration=Mock())
 
-        use_case.create_project(project_dto, self.user.email, extra_fields={}, authorizations=[])
+        use_case.create_project(
+            project_dto, self.user.email, extra_fields={}, authorizations=[]
+        )
 
-        channels = Channel.objects.filter(org=project.org, channel_type="WWC").order_by("created_on")
+        channels = Channel.objects.filter(org=project.org, channel_type="WWC").order_by(
+            "created_on"
+        )
         new_channel = channels.last()
 
         self.assertEqual(channels.count(), 2)
@@ -130,10 +144,16 @@ class ProjectCreationUseCaseTest(TembaTest):
 
         use_case = ProjectCreationUseCase(template_type_integration=Mock())
 
-        use_case.create_project(project_dto, self.user.email, extra_fields={}, authorizations=[])
+        use_case.create_project(
+            project_dto, self.user.email, extra_fields={}, authorizations=[]
+        )
 
-        self.assertEqual(Channel.objects.filter(org=project.org, channel_type="WWC").count(), 1)
-        self.assertEqual(Channel.objects.get(org=project.org, channel_type="WWC"), existing_channel)
+        self.assertEqual(
+            Channel.objects.filter(org=project.org, channel_type="WWC").count(), 1
+        )
+        self.assertEqual(
+            Channel.objects.get(org=project.org, channel_type="WWC"), existing_channel
+        )
         mock_connect_client.return_value.update_project.assert_called_once()
         mock_publish_channel_event.assert_not_called()
 
@@ -158,7 +178,170 @@ class ProjectCreationUseCaseTest(TembaTest):
 
         use_case = ProjectCreationUseCase(template_type_integration=Mock())
 
-        use_case.create_project(project_dto, user_email, extra_fields={}, authorizations=[])
+        use_case.create_project(
+            project_dto, user_email, extra_fields={}, authorizations=[]
+        )
 
         project = self.project.__class__.objects.get(project_uuid=project_uuid)
         self.assertTrue(project.config.get("is_multi_agents"))
+
+    @patch("temba.projects.usecases.project_creation.ConnectInternalClient")
+    @patch("temba.projects.usecases.channel_creation.publish_channel_event")
+    def test_create_project_creates_copilot_wwc_channel_when_live_desk_copilot(
+        self, mock_publish_channel_event, mock_connect_client
+    ):
+        user_email = "copilot-admin@example.com"
+        project_uuid = uuid.uuid4()
+        project_dto = ProjectCreationDTO(
+            uuid=str(project_uuid),
+            name="Projeto Copilot",
+            is_template=False,
+            date_format="D",
+            timezone=pytz.timezone("Africa/Kigali"),
+            template_type_uuid="",
+            description="Projeto Copilot",
+            brain_on=False,
+            is_live_desk_copilot=True,
+        )
+
+        use_case = ProjectCreationUseCase(template_type_integration=Mock())
+
+        use_case.create_project(
+            project_dto, user_email, extra_fields={}, authorizations=[]
+        )
+
+        project = self.project.__class__.objects.get(project_uuid=project_uuid)
+        channels = Channel.objects.filter(org=project.org, channel_type="WWC").order_by(
+            "created_on"
+        )
+
+        self.assertEqual(channels.count(), 2)
+
+        preview_channel = next(
+            channel for channel in channels if channel.config.get("preview")
+        )
+        copilot_channel = next(
+            channel
+            for channel in channels
+            if channel.config.get("is_live_desk_copilot")
+        )
+
+        self.assertIsNotNone(preview_channel)
+        self.assertEqual(preview_channel.name, DEFAULT_WWC_CHANNEL_NAME)
+        self.assertTrue(preview_channel.config["preview"])
+
+        self.assertIsNotNone(copilot_channel)
+        self.assertEqual(copilot_channel.name, COPILOT_WWC_CHANNEL_NAME)
+        self.assertTrue(copilot_channel.config["is_live_desk_copilot"])
+        self.assertFalse(copilot_channel.config.get("preview"))
+
+        self.assertEqual(mock_publish_channel_event.call_count, 2)
+        mock_publish_channel_event.assert_any_call(preview_channel, action="create")
+        mock_publish_channel_event.assert_any_call(copilot_channel, action="create")
+
+    @patch("temba.projects.usecases.project_creation.ConnectInternalClient")
+    @patch("temba.projects.usecases.channel_creation.publish_channel_event")
+    def test_create_project_reuses_existing_copilot_channel(
+        self, mock_publish_channel_event, mock_connect_client
+    ):
+        project_uuid = uuid.uuid4()
+        project = self.project.__class__.objects.create(
+            project_uuid=project_uuid,
+            name="Projeto com Copilot existente",
+            timezone=pytz.timezone("Africa/Kigali"),
+            brand=settings.DEFAULT_BRAND,
+            created_by=self.user,
+            modified_by=self.user,
+        )
+
+        existing_copilot = Channel.create(
+            org=project.org,
+            user=self.user,
+            country=None,
+            channel_type="WWC",
+            name=COPILOT_WWC_CHANNEL_NAME,
+            address=f"{project.project_uuid}-copilot",
+            config={"is_live_desk_copilot": True},
+        )
+
+        project_dto = ProjectCreationDTO(
+            uuid=str(project_uuid),
+            name="Projeto com Copilot existente",
+            is_template=False,
+            date_format="D",
+            timezone=pytz.timezone("Africa/Kigali"),
+            template_type_uuid="",
+            description="Projeto existente",
+            brain_on=False,
+            is_live_desk_copilot=True,
+        )
+
+        use_case = ProjectCreationUseCase(template_type_integration=Mock())
+
+        use_case.create_project(
+            project_dto, self.user.email, extra_fields={}, authorizations=[]
+        )
+
+        copilot_channels = [
+            channel
+            for channel in Channel.objects.filter(org=project.org, channel_type="WWC")
+            if channel.config.get("is_live_desk_copilot")
+        ]
+
+        self.assertEqual(len(copilot_channels), 1)
+        self.assertEqual(copilot_channels[0], existing_copilot)
+        mock_publish_channel_event.assert_called_once()
+
+    @patch("temba.projects.usecases.project_creation.ConnectInternalClient")
+    @patch("temba.projects.usecases.channel_creation.publish_channel_event")
+    def test_create_project_creates_preview_when_copilot_exists(
+        self, mock_publish_channel_event, mock_connect_client
+    ):
+        project_uuid = uuid.uuid4()
+        project = self.project.__class__.objects.create(
+            project_uuid=project_uuid,
+            name="Projeto só Copilot",
+            timezone=pytz.timezone("Africa/Kigali"),
+            brand=settings.DEFAULT_BRAND,
+            created_by=self.user,
+            modified_by=self.user,
+        )
+
+        Channel.create(
+            org=project.org,
+            user=self.user,
+            country=None,
+            channel_type="WWC",
+            name=COPILOT_WWC_CHANNEL_NAME,
+            address=f"{project.project_uuid}-copilot",
+            config={"is_live_desk_copilot": True},
+        )
+
+        project_dto = ProjectCreationDTO(
+            uuid=str(project_uuid),
+            name="Projeto só Copilot",
+            is_template=False,
+            date_format="D",
+            timezone=pytz.timezone("Africa/Kigali"),
+            template_type_uuid="",
+            description="Projeto existente",
+            brain_on=False,
+        )
+
+        use_case = ProjectCreationUseCase(template_type_integration=Mock())
+
+        use_case.create_project(
+            project_dto, self.user.email, extra_fields={}, authorizations=[]
+        )
+
+        preview_channels = [
+            channel
+            for channel in Channel.objects.filter(org=project.org, channel_type="WWC")
+            if channel.config.get("preview")
+        ]
+
+        self.assertEqual(len(preview_channels), 1)
+        self.assertEqual(preview_channels[0].name, DEFAULT_WWC_CHANNEL_NAME)
+        mock_publish_channel_event.assert_called_once_with(
+            preview_channels[0], action="create"
+        )


### PR DESCRIPTION
## What

- Create a hidden WWC Copilot channel when projects are created via EDA with is_live_desk_copilot=True
- Include is_live_desk_copilot flag in channel-created EDA events
- Hide Copilot and preview channels from UI and block edit/delete

## Why

Projects with Live Desk Copilot need an automatic WWC channel for the Copilot experience without exposing it in the Flows interface.